### PR TITLE
[BE-14] local 내장 redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-data-redis'
+
+    // embedded redis
+    implementation('it.ozimov:embedded-redis:0.7.3') {
+        exclude group : "org.slf4j", module : "slf4j-simple"
+    }
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/recodeit/server/configuration/LocalRedisConfiguration.java
+++ b/src/main/java/com/recodeit/server/configuration/LocalRedisConfiguration.java
@@ -1,0 +1,32 @@
+package com.recodeit.server.configuration;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+@Configuration
+@Profile("local")
+public class LocalRedisConfiguration {
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-14 / 테스트용 내장 redis 적용](https://recodeit.atlassian.net/jira/software/projects/BE/boards/3?selectedIssue=BE-14)
- 상위 이슈: [BE13-dev/local 환경 분리](https://recodeit.atlassian.net/jira/software/projects/BE/boards/3?selectedIssue=BE-13)
## 설명
- profiles : local 전용 내장 Redis 설정
## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] build.gradle에 내장 redis 의존성 추가
- [x] LocalRedisConfiguration 작성
## 질문사항
