### PR TITLE
[BE-14] 테스트용 내장 redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-data-redis'
+
+    // embedded redis
+    implementation('it.ozimov:embedded-redis:0.7.3') {
+        exclude group : "org.slf4j", module : "slf4j-simple"
+    }
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/test/java/com/recodeit/server/RecodeItServerApplicationTests.java
+++ b/src/test/java/com/recodeit/server/RecodeItServerApplicationTests.java
@@ -3,9 +3,10 @@ package com.recodeit.server;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@Profile("test")
+@ActiveProfiles("test")
 class RecodeItServerApplicationTests {
 
     @Test

--- a/src/test/java/com/recodeit/server/RecodeItServerApplicationTests.java
+++ b/src/test/java/com/recodeit/server/RecodeItServerApplicationTests.java
@@ -2,8 +2,10 @@ package com.recodeit.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 
 @SpringBootTest
+@Profile("test")
 class RecodeItServerApplicationTests {
 
     @Test

--- a/src/test/java/com/recodeit/server/configuration/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/recodeit/server/configuration/EmbeddedRedisConfiguration.java
@@ -9,19 +9,15 @@ import redis.embedded.RedisServer;
 
 @Configuration
 @Profile("test")
-public class LocalRedisConfiguration {
+public class EmbeddedRedisConfiguration {
 
     private final int redisPort;
 
-    private RedisServer redisServer;
+    private final RedisServer redisServer;
 
-    public LocalRedisConfiguration(@Value("${spring.redis.port}") int redisPort) {
+    protected EmbeddedRedisConfiguration(@Value("${spring.redis.port}") int redisPort) {
         this.redisPort = redisPort;
-    }
-
-    @PostConstruct
-    public void startRedis() {
-        redisServer = new RedisServer(redisPort);
+        this.redisServer = new RedisServer(redisPort);
         redisServer.start();
     }
 

--- a/src/test/java/com/recodeit/server/configuration/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/recodeit/server/configuration/EmbeddedRedisConfiguration.java
@@ -1,6 +1,5 @@
 package com.recodeit.server.configuration;
 
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -11,18 +10,15 @@ import redis.embedded.RedisServer;
 @Profile("test")
 public class EmbeddedRedisConfiguration {
 
-    private final int redisPort;
-
     private final RedisServer redisServer;
 
     protected EmbeddedRedisConfiguration(@Value("${spring.redis.port}") int redisPort) {
-        this.redisPort = redisPort;
         this.redisServer = new RedisServer(redisPort);
         redisServer.start();
     }
 
     @PreDestroy
-    public void stop() {
+    private void stop() {
         if (redisServer != null) {
             redisServer.stop();
         }

--- a/src/test/java/com/recodeit/server/configuration/LocalRedisConfiguration.java
+++ b/src/test/java/com/recodeit/server/configuration/LocalRedisConfiguration.java
@@ -1,0 +1,34 @@
+package com.recodeit.server.configuration;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+@Configuration
+@Profile("test")
+public class LocalRedisConfiguration {
+
+    private final int redisPort;
+
+    private RedisServer redisServer;
+
+    public LocalRedisConfiguration(@Value("${spring.redis.port}") int redisPort) {
+        this.redisPort = redisPort;
+    }
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-14 / 테스트용 내장 redis 적용](https://recodeit.atlassian.net/jira/software/projects/BE/boards/3?selectedIssue=BE-14)
- 상위 이슈: [BE13-dev/local 환경 분리](https://recodeit.atlassian.net/jira/software/projects/BE/boards/3?selectedIssue=BE-13)
## 설명
테스트 코드 동작 시 내장 Redis를 사용하기 위해 내장 Redis를 적용하였습니다.

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] build.gradle에 내장 redis 의존성 추가
- [x] LocalRedisConfiguration 작성
## 질문사항
