### PR TITLE
[BE-48] Swagger3.0.0 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
     // embedded redis
     implementation('it.ozimov:embedded-redis:0.7.3') {

--- a/src/main/java/com/recodeit/server/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/recodeit/server/configuration/SwaggerConfiguration.java
@@ -1,0 +1,30 @@
+package com.recodeit.server.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfiguration {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.recodeit"))
+                .paths(PathSelectors.any())
+                .build().apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo(){
+        return new ApiInfoBuilder()
+                .title("RecordIt Backend - DEV")
+                .description("RecordIt Backend - DEV 서버 API 명세")
+                .version("1.0")
+                .build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,9 @@ spring:
   config:
     activate:
       on-profile: "dev"
-
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
   jpa:
     open-in-view: true
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,9 @@ spring:
   config:
     activate:
       on-profile: "local"
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
 
   jpa:
     open-in-view: true


### PR DESCRIPTION
## 관련 이슈 번호
[BE-48 / Swagger 추가/설정](https://recodeit.atlassian.net/jira/software/projects/BE/boards/3/backlog?selectedIssue=BE-48)
## 설명
Swagger3.0.0 적용 하였습니다

Spring boot 2.6버전 이후에 spring.mvc.pathmatch.matching-strategy 값이 ant_apth_matcher에서 path_pattern_parser로 변경되면서 몇몇 라이브러리(swagger포함)에 오류가 발생한다고 하여 application.yml 에 아래 설정을 추가하였습니다.
```yml
spring:
  mvc:
    pathmatch:
      matching-strategy: ant_path_matcher
```
## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] build.readle에 dependency 추가
- [x] SwaggerConfiguration.java 작성
- [x] dev, local yml에 설정 추가
## 질문사항
