### PR TITLE
[BE-20] SessionUtil 생성

### DIFF
--- a/src/main/java/com/recodeit/server/exception/NotFoundUserInfoInSessionException.java
+++ b/src/main/java/com/recodeit/server/exception/NotFoundUserInfoInSessionException.java
@@ -1,0 +1,4 @@
+package com.recodeit.server.exception;
+
+public class NotFoundUserInfoInSessionException extends RuntimeException {
+}

--- a/src/main/java/com/recodeit/server/exception/NotFoundUserInfoInSessionException.java
+++ b/src/main/java/com/recodeit/server/exception/NotFoundUserInfoInSessionException.java
@@ -1,4 +1,7 @@
 package com.recodeit.server.exception;
 
 public class NotFoundUserInfoInSessionException extends RuntimeException {
+	public NotFoundUserInfoInSessionException(String message) {
+		super(message);
+	}
 }

--- a/src/main/java/com/recodeit/server/util/SessionUtil.java
+++ b/src/main/java/com/recodeit/server/util/SessionUtil.java
@@ -27,7 +27,7 @@ public class SessionUtil {
 		return userId;
 	}
 
-	public void removeSession() {
+	public void invalidateSession() {
 		httpSession.invalidate();
 	}
 }

--- a/src/main/java/com/recodeit/server/util/SessionUtil.java
+++ b/src/main/java/com/recodeit/server/util/SessionUtil.java
@@ -1,0 +1,33 @@
+package com.recodeit.server.util;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+
+import com.recodeit.server.exception.NotFoundUserInfoInSessionException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionUtil {
+
+	private static final String PREFIX_USER_ID = "LOGIN_USER_ID";
+	private final HttpSession httpSession;
+
+	public void saveUserIdInSession(Long id) {
+		httpSession.setAttribute(PREFIX_USER_ID, id);
+	}
+
+	public Long findUserIdBySession() {
+		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
+		if (userId == null) {
+			throw new NotFoundUserInfoInSessionException();
+		}
+		return userId;
+	}
+
+	public void removeSession() {
+		httpSession.invalidate();
+	}
+}

--- a/src/main/java/com/recodeit/server/util/SessionUtil.java
+++ b/src/main/java/com/recodeit/server/util/SessionUtil.java
@@ -22,7 +22,7 @@ public class SessionUtil {
 	public Long findUserIdBySession() {
 		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
-			throw new NotFoundUserInfoInSessionException();
+			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
 		return userId;
 	}

--- a/src/test/java/com/recodeit/server/util/SessionUtilTest.java
+++ b/src/test/java/com/recodeit/server/util/SessionUtilTest.java
@@ -71,7 +71,7 @@ public class SessionUtilTest {
 		// given
 
 		// when
-		sessionUtil.removeSession();
+		sessionUtil.invalidateSession();
 
 		// then
 		assertThat(mockHttpSession.isInvalid()).isTrue();

--- a/src/test/java/com/recodeit/server/util/SessionUtilTest.java
+++ b/src/test/java/com/recodeit/server/util/SessionUtilTest.java
@@ -1,0 +1,80 @@
+package com.recodeit.server.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpSession;
+
+import com.recodeit.server.exception.NotFoundUserInfoInSessionException;
+
+@ExtendWith(MockitoExtension.class)
+public class SessionUtilTest {
+
+	@InjectMocks
+	private SessionUtil sessionUtil;
+
+	@Spy
+	MockHttpSession mockHttpSession;
+
+	@Test
+	@DisplayName("세션에 userId를 저장하는 기능을 테스트한다")
+	void 세션에_UserId를_저장하는_기능을_테스트한다() {
+		// given
+
+		// when
+		sessionUtil.saveUserIdInSession(1L);
+
+		// then
+		assertThat(mockHttpSession.getAttribute("LOGIN_USER_ID")).isEqualTo((Long)1L);
+	}
+
+	@Nested
+	@DisplayName("세션에서 userId를 찾을 때")
+	class 세션에서_userId를_찾을_때 {
+
+		@Test
+		@DisplayName("세션에 userId가 있으면 값이 찾아와진다")
+		void 세션에_정상적으로_userId를_저장하고_있으면_정상적으로_값이_찾아와진다() {
+			// given
+			long userId = 1L;
+			mockHttpSession.setAttribute("LOGIN_USER_ID", userId);
+
+			// when
+			Long userIdBySession = sessionUtil.findUserIdBySession();
+
+			// then
+			assertThat(userIdBySession.longValue()).isEqualTo(userId);
+			assertThatCode(() -> sessionUtil.findUserIdBySession()).doesNotThrowAnyException();
+		}
+
+		@Test
+		@DisplayName("세션에 userId가 없으면 예외를 던진다")
+		void 세션에_userId가_없으면_예외를_던진다() {
+			// given
+
+			// when, then
+			assertThatThrownBy(() -> sessionUtil.findUserIdBySession())
+					.isInstanceOf(NotFoundUserInfoInSessionException.class);
+
+		}
+	}
+
+	@Test
+	@DisplayName("세션을 삭제하는 기능을 테스트한다")
+	void 세션을_삭제하는_기능을_테스트한다() {
+		// given
+
+		// when
+		sessionUtil.removeSession();
+
+		// then
+		assertThat(mockHttpSession.isInvalid()).isTrue();
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-20 / profile 작성](https://recodeit.atlassian.net/browse/BE-20)

## 설명
SessionUtil 기능 구현 및 테스트 코드 작성

기능
- 세션에 userId 저장
- 세션에서 userId 읽기
- 세션 삭제

테스트 케이스
1. 세션을 저장할 때 정상적으로 저장되는지 테스트 추가
2. 세션에서 값을 불러올 때 happy/unhappy 테스트 추가
3. 세션 삭제 기능 테스트 추가

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] SessionUtill 기능 구현
- [x] SessionUtil 테스트 코드 추가

## 질문사항
