### PR TITLE
[BE-67] 기존 API 명세 Swagger로 이전

### DIFF
--- a/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
@@ -15,6 +15,7 @@ public class SwaggerConfiguration {
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.OAS_30)
+				.useDefaultResponseMessages(false)
 				.select()
 				.apis(RequestHandlerSelectors.basePackage("com.recordit"))
 				.paths(PathSelectors.any())

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -35,9 +35,9 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원가입",
-			notes = "로그인 타입, TEMPSESSIONID, 닉네임을 받아 회원가입을 진행합니다")
+			notes = "로그인 타입, register_session, 닉네임을 받아 회원가입을 진행합니다")
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "API 정상 작동 / 세션 로그인 처리하고 Header에 Set-cookie: SESSION=; 헤더로 응답"),
+			@ApiResponse(code = 200, message = "API 정상 작동 / 회원가입을 진행하고 세션 로그인 처리하고 Header에 Set-cookie: SESSION=; 헤더로 응답"),
 			@ApiResponse(code = 428, message = "register_session 정보가 Redis에 없거나 비정상적일 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.recordit.server.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,9 +41,19 @@ public class MemberController {
 			@ApiResponse(code = 428, message = "TEMPSESSIONUUID 정보가 Redis에 없거나 비정상적일 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
-
 	@PostMapping("/oauth/register/{loginType}")
 	public void oauthRegister(@PathVariable("loginType") String loginType, @RequestBody String nickname) {
 		memberService.oauthRegister(loginType);
+	}
+
+	@ApiOperation(value = "닉네임 중복확인",
+			notes = "닉네임을 받아 해당 닉네임이 중복되었는지 판별")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "닉네임이 사용 가능한 경우"),
+			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
+	})
+	@GetMapping
+	public void duplicateNicknameCheck(@RequestBody String nickname) {
+
 	}
 }

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.recordit.server.controller;
 
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.recordit.server.service.MemberService;
@@ -15,7 +16,7 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@PostMapping("/member/oauth/{loginType}")
-	public void oauthLogin(@PathVariable("loginType") String loginType) {
+	public void oauthLogin(@PathVariable("loginType") String loginType, @RequestBody String token) {
 		memberService.oauthLogin(loginType);
 	}
 

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -22,11 +22,11 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@ApiOperation(value = "로그인",
-			notes = "로그인 타입과 세션을 받아 가입된 회원이라면 로그인을 진행시키고 Header에 setCookie로 응답합니다")
+			notes = "로그인 타입과 세션을 받아 가입된 회원이라면 로그인을 진행시키고 Header에 Set-cookie: SESSION=;응답합니다")
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "API 정상 작동 / Header에 setCookie값 응답"),
+			@ApiResponse(code = 200, message = "API 정상 작동 / Header에 Set-cookie: SESSION=;응답"),
 			@ApiResponse(code = 401, message = "회원정보가 없어 회원가입이 필요한 경우입니다."
-					+ "Body로 응답된 TEMPSESSIONUUID와 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요")
+					+ "Body로 응답된 register_session과 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요")
 	})
 	@PostMapping("/oauth/login/{loginType}")
 	public void oauthLogin(
@@ -37,8 +37,8 @@ public class MemberController {
 	@ApiOperation(value = "회원가입",
 			notes = "로그인 타입, TEMPSESSIONID, 닉네임을 받아 회원가입을 진행합니다")
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "API 정상 작동 / 세션 로그인 처리하고 SESSIONID 헤더로 응답"),
-			@ApiResponse(code = 428, message = "TEMPSESSIONUUID 정보가 Redis에 없거나 비정상적일 경우"),
+			@ApiResponse(code = 200, message = "API 정상 작동 / 세션 로그인 처리하고 Header에 Set-cookie: SESSION=; 헤더로 응답"),
+			@ApiResponse(code = 428, message = "register_session 정보가 Redis에 없거나 비정상적일 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
 	@PostMapping("/oauth/register/{loginType}")

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.recordit.server.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +14,7 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@GetMapping("/member/oauth/{loginType}")
+	@PostMapping("/member/oauth/{loginType}")
 	public void oauthLogin(@PathVariable("loginType") String loginType) {
 		memberService.oauthLogin(loginType);
 	}

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -3,25 +3,46 @@ package com.recordit.server.controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.recordit.server.service.MemberService;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/member")
 public class MemberController {
 
 	private final MemberService memberService;
 
-	@PostMapping("/member/oauth/{loginType}")
-	public void oauthLogin(@PathVariable("loginType") String loginType, @RequestBody String token) {
+	@ApiOperation(value = "로그인",
+			notes = "로그인 타입과 세션을 받아 가입된 회원이라면 로그인을 진행시키고 Header에 setCookie로 응답합니다")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "API 정상 작동 / Header에 setCookie값 응답"),
+			@ApiResponse(code = 401, message = "회원정보가 없어 회원가입이 필요한 경우입니다."
+					+ "Body로 응답된 TEMPSESSIONUUID와 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요")
+	})
+	@PostMapping("/oauth/login/{loginType}")
+	public void oauthLogin(
+			@PathVariable("loginType") String loginType, @RequestBody String token) {
 		memberService.oauthLogin(loginType);
 	}
 
-	@PostMapping("/member/oauth/{loginType}")
-	public void oauthRegister(@PathVariable("loginType") String loginType) {
+	@ApiOperation(value = "회원가입",
+			notes = "로그인 타입, TEMPSESSIONID, 닉네임을 받아 회원가입을 진행합니다")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "API 정상 작동 / 세션 로그인 처리하고 SESSIONID 헤더로 응답"),
+			@ApiResponse(code = 428, message = "TEMPSESSIONUUID 정보가 Redis에 없거나 비정상적일 경우"),
+			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
+	})
+
+	@PostMapping("/oauth/register/{loginType}")
+	public void oauthRegister(@PathVariable("loginType") String loginType, @RequestBody String nickname) {
 		memberService.oauthRegister(loginType);
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-67 / 기존 API 명세 Swagger로 이전](https://recodeit.atlassian.net/browse/BE-67)

## 설명

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] MemberController에 ApiOperation, ApiResponse 정의
- [x] 닉네임 중복확인 메서드 정의
- [x]  Swagger에 기본 응답코드 안나오게 설정
- [x] oauthLogin Get -> Post로 수정 

## 질문사항
