### PR TITLE
[BE-71] 로그인/회원가입 DTO 생성 및 스웨거 적용

### DIFF
--- a/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
@@ -14,7 +14,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 public class SwaggerConfiguration {
 	@Bean
 	public Docket api() {
-		return new Docket(DocumentationType.OAS_30)
+		return new Docket(DocumentationType.SWAGGER_2)
 				.useDefaultResponseMessages(false)
 				.select()
 				.apis(RequestHandlerSelectors.basePackage("com.recordit"))

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -1,17 +1,24 @@
 package com.recordit.server.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.RegisterRequestDto;
+import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.service.MemberService;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ResponseHeader;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,39 +28,63 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@ApiOperation(value = "로그인",
-			notes = "로그인 타입과 세션을 받아 가입된 회원이라면 로그인을 진행시키고 Header에 Set-cookie: SESSION=;응답합니다")
+	@ApiOperation(
+			value = "Oauth 로그인",
+			notes = "로그인 타입과 Oauth 토큰을 통해 Oauth 로그인을 진행합니다."
+	)
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "API 정상 작동 / Header에 Set-cookie: SESSION=;응답"),
-			@ApiResponse(code = 401, message = "회원정보가 없어 회원가입이 필요한 경우입니다."
-					+ "Body로 응답된 register_session과 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요")
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / Header에 세션 응답",
+					responseHeaders = {
+							@ResponseHeader(name = "Set-cookie: SESSION=FOO;", description = "FOO = 서버의 세션", response = String.class)
+					}
+			),
+			@ApiResponse(
+					code = 401, message = "회원정보가 없어 회원가입이 필요한 경우입니다\t\n"
+					+ "Body로 응답된 register_session과 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요",
+					response = RegisterSessionResponseDto.class
+			)
 	})
 	@PostMapping("/oauth/login/{loginType}")
-	public void oauthLogin(
-			@PathVariable("loginType") String loginType, @RequestBody String token) {
+	public ResponseEntity oauthLogin(
+			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
+			@RequestBody LoginRequestDto loginRequestDto
+	) {
 		memberService.oauthLogin(loginType);
+		return ResponseEntity.ok(null);
 	}
 
-	@ApiOperation(value = "회원가입",
-			notes = "로그인 타입, register_session, 닉네임을 받아 회원가입을 진행합니다")
+	@ApiOperation(
+			value = "회원가입",
+			notes = "로그인 타입, register_session, 닉네임을 받아 회원가입을 진행합니다"
+	)
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "API 정상 작동 / 회원가입을 진행하고 세션 로그인 처리하고 Header에 Set-cookie: SESSION=; 헤더로 응답"),
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / Header에 세션 응답",
+					responseHeaders = {
+							@ResponseHeader(name = "Set-cookie: SESSION=FOO;", description = "FOO = 서버의 세션", response = String.class)
+					}
+			),
 			@ApiResponse(code = 428, message = "register_session 정보가 Redis에 없거나 비정상적일 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
 	@PostMapping("/oauth/register/{loginType}")
-	public void oauthRegister(@PathVariable("loginType") String loginType, @RequestBody String nickname) {
+	public void oauthRegister(
+			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
+			@RequestBody RegisterRequestDto registerRequestDto
+	) {
 		memberService.oauthRegister(loginType);
 	}
 
-	@ApiOperation(value = "닉네임 중복확인",
-			notes = "닉네임을 받아 해당 닉네임이 중복되었는지 판별")
+	@ApiOperation(
+			value = "닉네임 중복확인",
+			notes = "닉네임을 받아 해당 닉네임이 중복되었는지 판별"
+	)
 	@ApiResponses({
 			@ApiResponse(code = 200, message = "닉네임이 사용 가능한 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
-	@GetMapping
-	public void duplicateNicknameCheck(@RequestBody String nickname) {
-
+	@GetMapping("/nickname")
+	public void duplicateNicknameCheck(@RequestParam String nickname) {
 	}
 }

--- a/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
@@ -1,0 +1,22 @@
+package com.recordit.server.dto.member;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LoginRequestDto {
+
+	@ApiModelProperty(notes = "Oauth API에서 응답 받은 토큰", required = true)
+	private String oauthToken;
+}

--- a/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
@@ -1,0 +1,26 @@
+package com.recordit.server.dto.member;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RegisterRequestDto {
+
+	@ApiModelProperty(notes = "회원가입시 필요한 임시 Session", required = true)
+	private String registerSession;
+
+	@ApiModelProperty(notes = "사용자 닉네임", required = true)
+	private String nickname;
+
+}

--- a/src/main/java/com/recordit/server/dto/member/RegisterSessionResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterSessionResponseDto.java
@@ -1,0 +1,28 @@
+package com.recordit.server.dto.member;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RegisterSessionResponseDto {
+
+	@ApiModelProperty(notes = "회원가입시 필요한 임시 Session", required = true)
+	private String registerSession;
+
+	@Builder
+	public RegisterSessionResponseDto(String registerSession) {
+		this.registerSession = registerSession;
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,3 +22,7 @@ spring:
     level:
       '[org.springframework.web]': DEBUG
       '[org.hibernate]': DEBUG
+springfox:
+  documentation:
+    swagger:
+      use-model-v3: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,7 @@ spring:
     level:
       '[org.springframework.web]': DEBUG
       '[org.hibernate]': DEBUG
+springfox:
+  documentation:
+    swagger:
+      use-model-v3: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,3 +21,7 @@ spring:
     password:
   session:
     store-type: redis
+springfox:
+  documentation:
+    swagger:
+      use-model-v3: false


### PR DESCRIPTION
## 관련 이슈 번호

[BE-71 / 로그인/회원가입 DTO 생성 및 스웨거 적용](https://recodeit.atlassian.net/browse/BE-71)

## 설명
- 로그인/회원가입 관련 DTO 생성
- 생선한 DTO를 스웨거에 적용
- 로그인/회원가입 관련 스웨거 명세서 수정
- 스웨거 관련 @ApiResponse에서 response에 DTO 클래스를 지정하는 기능 오작동으로 해당 파일들을 수정해서 고침

## 변경사항

- [x] LoginRequestDto 추가
- [x] RegisterRequestDto 추가
- [x] RegisterSessionResponseDto 추가
- [x]  MemberController에 생성한 DTO 스웨거 명세서에 추가 및 수정

## 질문사항
