### PR TITLE
[BE-29] 로그인/회원가입 요구사항에 따른 테스트코드 및 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // use static mock
+    testImplementation 'org.mockito:mockito-inline:4.5.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/recordit/server/configuration/RedisConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/RedisConfiguration.java
@@ -6,8 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -37,10 +36,10 @@ public class RedisConfiguration {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+	public StringRedisTemplate redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		StringRedisTemplate redisTemplate = new StringRedisTemplate();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
 		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		return redisTemplate;
 	}

--- a/src/main/java/com/recordit/server/constant/RegisterSessionConstants.java
+++ b/src/main/java/com/recordit/server/constant/RegisterSessionConstants.java
@@ -1,0 +1,6 @@
+package com.recordit.server.constant;
+
+public class RegisterSessionConstants {
+	public static final String PREFIX_REGISTER_SESSION = "REGISTER_SESSION=";
+	public static final long TIMEOUT = 30;
+}

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -41,6 +41,9 @@ public class MemberController {
 					}
 			),
 			@ApiResponse(
+					code = 400, message = "API에서 지정한 LoginType이 아닐 경우입니다"
+			),
+			@ApiResponse(
 					code = 401, message = "회원정보가 없어 회원가입이 필요한 경우입니다\t\n"
 					+ "Body로 응답된 register_session과 사용자에게 닉네임을 받아 '/member/oauth/register/{loginType}'으로 요청하세요",
 					response = RegisterSessionResponseDto.class
@@ -64,6 +67,9 @@ public class MemberController {
 					responseHeaders = {
 							@ResponseHeader(name = "Set-cookie: SESSION=FOO;", description = "FOO = 서버의 세션", response = String.class)
 					}
+			),
+			@ApiResponse(
+					code = 400, message = "API에서 지정한 LoginType이 아닐 경우입니다"
 			),
 			@ApiResponse(code = 428, message = "register_session 정보가 Redis에 없거나 비정상적일 경우"),
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.recordit.server.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,8 +51,7 @@ public class MemberController {
 			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
 			@RequestBody LoginRequestDto loginRequestDto
 	) {
-		memberService.oauthLogin(loginType);
-		return ResponseEntity.ok(null);
+		return new ResponseEntity(memberService.oauthLogin(loginType, loginRequestDto), HttpStatus.UNAUTHORIZED);
 	}
 
 	@ApiOperation(
@@ -69,11 +69,12 @@ public class MemberController {
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
 	@PostMapping("/oauth/register/{loginType}")
-	public void oauthRegister(
+	public ResponseEntity oauthRegister(
 			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
 			@RequestBody RegisterRequestDto registerRequestDto
 	) {
-		memberService.oauthRegister(loginType);
+		memberService.oauthRegister(loginType, registerRequestDto);
+		return new ResponseEntity(HttpStatus.OK);
 	}
 
 	@ApiOperation(
@@ -85,6 +86,8 @@ public class MemberController {
 			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
 	})
 	@GetMapping("/nickname")
-	public void duplicateNicknameCheck(@RequestParam String nickname) {
+	public ResponseEntity duplicateNicknameCheck(@RequestParam String nickname) {
+		memberService.isDuplicateNickname(nickname);
+		return new ResponseEntity(HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.recordit.server.controller;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,7 +56,15 @@ public class MemberController {
 			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
 			@RequestBody LoginRequestDto loginRequestDto
 	) {
-		return new ResponseEntity(memberService.oauthLogin(loginType, loginRequestDto), HttpStatus.UNAUTHORIZED);
+
+		Optional<RegisterSessionResponseDto> registerSessionResponseDto = memberService.oauthLogin(
+				loginType,
+				loginRequestDto
+		);
+		if (registerSessionResponseDto.isEmpty()) {
+			return ResponseEntity.ok().build();
+		}
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(registerSessionResponseDto.get());
 	}
 
 	@ApiOperation(
@@ -96,4 +106,5 @@ public class MemberController {
 		memberService.isDuplicateNickname(nickname);
 		return new ResponseEntity(HttpStatus.OK);
 	}
+
 }

--- a/src/main/java/com/recordit/server/domain/Member.java
+++ b/src/main/java/com/recordit/server/domain/Member.java
@@ -46,6 +46,7 @@ public class Member extends BaseEntity {
 	private LoginType loginType;
 
 	private Member(String username, String password, String nickname, String oauthId, LoginType loginType) {
+		this.username = username;
 		this.password = password;
 		this.nickname = nickname;
 		this.oauthId = oauthId;

--- a/src/main/java/com/recordit/server/domain/Member.java
+++ b/src/main/java/com/recordit/server/domain/Member.java
@@ -45,14 +45,14 @@ public class Member extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private LoginType loginType;
 
-	private Member(String password, String nickname, String oauthId, LoginType loginType) {
+	private Member(String username, String password, String nickname, String oauthId, LoginType loginType) {
 		this.password = password;
 		this.nickname = nickname;
 		this.oauthId = oauthId;
 		this.loginType = loginType;
 	}
 
-	public static Member of(String password, String nickname, String oauthId, LoginType loginType) {
-		return new Member(password, nickname, oauthId, loginType);
+	public static Member of(String username, String password, String nickname, String oauthId, LoginType loginType) {
+		return new Member(username, password, nickname, oauthId, loginType);
 	}
 }

--- a/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -19,4 +20,9 @@ public class LoginRequestDto {
 
 	@ApiModelProperty(notes = "Oauth API에서 응답 받은 토큰", required = true)
 	private String oauthToken;
+
+	@Builder
+	public LoginRequestDto(String oauthToken) {
+		this.oauthToken = oauthToken;
+	}
 }

--- a/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -23,4 +24,9 @@ public class RegisterRequestDto {
 	@ApiModelProperty(notes = "사용자 닉네임", required = true)
 	private String nickname;
 
+	@Builder
+	public RegisterRequestDto(String registerSession, String nickname) {
+		this.registerSession = registerSession;
+		this.nickname = nickname;
+	}
 }

--- a/src/main/java/com/recordit/server/exception/member/DuplicateNicknameException.java
+++ b/src/main/java/com/recordit/server/exception/member/DuplicateNicknameException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.member;
+
+public class DuplicateNicknameException extends RuntimeException {
+	public DuplicateNicknameException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
@@ -38,5 +38,12 @@ public class MemberExceptionHandler {
 		return ResponseEntity.status(HttpStatus.CONFLICT)
 				.body(ErrorMessage.of(exception, HttpStatus.CONFLICT));
 	}
+
+	@ExceptionHandler(NotFoundRegisterSessionException.class)
+	public ResponseEntity<ErrorMessage> handleNotFoundRegisterSessionException(
+			NotFoundRegisterSessionException exception) {
+		return ResponseEntity.status(HttpStatus.PRECONDITION_REQUIRED)
+				.body(ErrorMessage.of(exception, HttpStatus.PRECONDITION_REQUIRED));
+	}
 }
 

--- a/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
@@ -32,5 +32,11 @@ public class MemberExceptionHandler {
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
+
+	@ExceptionHandler(DuplicateNicknameException.class)
+	public ResponseEntity<ErrorMessage> handleDuplicateNicknameException(DuplicateNicknameException exception) {
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body(ErrorMessage.of(exception, HttpStatus.CONFLICT));
+	}
 }
 

--- a/src/main/java/com/recordit/server/exception/member/NotFoundRegisterSessionException.java
+++ b/src/main/java/com/recordit/server/exception/member/NotFoundRegisterSessionException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.member;
+
+public class NotFoundRegisterSessionException extends RuntimeException {
+	public NotFoundRegisterSessionException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/redis/RedisExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/redis/RedisExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.recordit.server.exception.redis;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.recordit.server.exception.ErrorMessage;
+import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class RedisExceptionHandler {
+
+	@ExceptionHandler(RedisParsingException.class)
+	public ResponseEntity<ErrorMessage> handleRedisParsingException(
+			NotFoundUserInfoInSessionException exception) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
+	}
+
+}

--- a/src/main/java/com/recordit/server/exception/redis/RedisExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/redis/RedisExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.recordit.server.exception.ErrorMessage;
-import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,8 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RedisExceptionHandler {
 
 	@ExceptionHandler(RedisParsingException.class)
-	public ResponseEntity<ErrorMessage> handleRedisParsingException(
-			NotFoundUserInfoInSessionException exception) {
+	public ResponseEntity<ErrorMessage> handleRedisParsingException(RedisParsingException exception) {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
 	}

--- a/src/main/java/com/recordit/server/exception/redis/RedisParsingException.java
+++ b/src/main/java/com/recordit/server/exception/redis/RedisParsingException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.redis;
+
+public class RedisParsingException extends RuntimeException {
+	public RedisParsingException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/repository/MemberRepository.java
+++ b/src/main/java/com/recordit/server/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.recordit.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.recordit.server.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/recordit/server/repository/MemberRepository.java
+++ b/src/main/java/com/recordit/server/repository/MemberRepository.java
@@ -1,10 +1,14 @@
 package com.recordit.server.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.recordit.server.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByOauthId(String oauthId);
 
 	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
+import com.recordit.server.exception.member.DuplicateNicknameException;
 import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthService;
 import com.recordit.server.service.oauth.OauthServiceLocator;
@@ -31,5 +32,8 @@ public class MemberService {
 
 	@Transactional(readOnly = true)
 	public void isDuplicateNickname(String nickname) {
+		if (memberRepository.existsByNickname(nickname)) {
+			throw new DuplicateNicknameException("중복된 닉네임이 존재합니다.");
+		}
 	}
 }

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -1,15 +1,26 @@
 package com.recordit.server.service;
 
+import static com.recordit.server.constant.RegisterSessionConstants.*;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.recordit.server.constant.LoginType;
+import com.recordit.server.domain.Member;
 import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
+import com.recordit.server.exception.member.NotFoundRegisterSessionException;
 import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthService;
 import com.recordit.server.service.oauth.OauthServiceLocator;
+import com.recordit.server.util.RedisManager;
+import com.recordit.server.util.SessionUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,16 +29,47 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final OauthServiceLocator oauthServiceLocator;
 	private final MemberRepository memberRepository;
+	private final SessionUtil sessionUtil;
+	private final RedisManager redisManager;
 
 	@Transactional
-	public RegisterSessionResponseDto oauthLogin(String loginType, LoginRequestDto loginRequestDto) {
+	public Optional<RegisterSessionResponseDto> oauthLogin(String loginType, LoginRequestDto loginRequestDto) {
 		OauthService oauthService = oauthServiceLocator.getOauthServiceByLoginType(loginType);
-		return null;
+
+		String oauthId = oauthService.request(loginRequestDto.getOauthToken());
+		Optional<Member> findMember = memberRepository.findByOauthId(oauthId);
+
+		if (findMember.isPresent()) {
+			sessionUtil.saveUserIdInSession(findMember.get().getId());
+			return Optional.empty();
+		}
+		String registerSessionUUID = UUID.randomUUID().toString();
+		redisManager.set(PREFIX_REGISTER_SESSION + registerSessionUUID, oauthId, TIMEOUT, TimeUnit.MINUTES);
+		return Optional.of(RegisterSessionResponseDto.builder()
+				.registerSession(registerSessionUUID)
+				.build());
 	}
 
 	@Transactional
 	public void oauthRegister(String loginType, RegisterRequestDto registerRequestDto) {
-		OauthService oauthService = oauthServiceLocator.getOauthServiceByLoginType(loginType);
+		Optional<String> oauthId = redisManager.get(
+				PREFIX_REGISTER_SESSION + registerRequestDto.getRegisterSession(),
+				String.class);
+		if (oauthId.isEmpty()) {
+			throw new NotFoundRegisterSessionException("Oauth 회원가입을 위한 register_session이 존재하지 않습니다.");
+		}
+
+		isDuplicateNickname(registerRequestDto.getNickname());
+		Member saveMember = memberRepository.save(
+				Member.of(
+						null,
+						null,
+						registerRequestDto.getNickname(),
+						oauthId.get(),
+						LoginType.findByString(loginType)
+				)
+		);
+		sessionUtil.saveUserIdInSession(saveMember.getId());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -3,6 +3,10 @@ package com.recordit.server.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.RegisterRequestDto;
+import com.recordit.server.dto.member.RegisterSessionResponseDto;
+import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthService;
 import com.recordit.server.service.oauth.OauthServiceLocator;
 
@@ -12,14 +16,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberService {
 	private final OauthServiceLocator oauthServiceLocator;
+	private final MemberRepository memberRepository;
 
 	@Transactional
-	public void oauthLogin(String loginType) {
+	public RegisterSessionResponseDto oauthLogin(String loginType, LoginRequestDto loginRequestDto) {
 		OauthService oauthService = oauthServiceLocator.getOauthServiceByLoginType(loginType);
+		return null;
 	}
 
 	@Transactional
-	public void oauthRegister(String loginType) {
+	public void oauthRegister(String loginType, RegisterRequestDto registerRequestDto) {
 		OauthService oauthService = oauthServiceLocator.getOauthServiceByLoginType(loginType);
+	}
+
+	@Transactional(readOnly = true)
+	public void isDuplicateNickname(String nickname) {
 	}
 }

--- a/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
@@ -12,7 +12,7 @@ public class GoogleOauthService implements OauthService {
 	}
 
 	@Override
-	public String request() {
+	public String request(String oauthToken) {
 		return null;
 	}
 }

--- a/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
@@ -12,7 +12,7 @@ public class GoogleOauthService implements OauthService {
 	}
 
 	@Override
-	public void request() {
-
+	public String request() {
+		return null;
 	}
 }

--- a/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
@@ -12,7 +12,7 @@ public class KakaoOauthService implements OauthService {
 	}
 
 	@Override
-	public void request() {
-
+	public String request() {
+		return null;
 	}
 }

--- a/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
@@ -12,7 +12,7 @@ public class KakaoOauthService implements OauthService {
 	}
 
 	@Override
-	public String request() {
+	public String request(String oauthToken) {
 		return null;
 	}
 }

--- a/src/main/java/com/recordit/server/service/oauth/OauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/OauthService.java
@@ -6,5 +6,5 @@ public interface OauthService {
 
 	LoginType getLoginType();
 
-	String request();
+	String request(String oauthToken);
 }

--- a/src/main/java/com/recordit/server/service/oauth/OauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/OauthService.java
@@ -6,5 +6,5 @@ public interface OauthService {
 
 	LoginType getLoginType();
 
-	void request();
+	String request();
 }

--- a/src/main/java/com/recordit/server/util/RedisManager.java
+++ b/src/main/java/com/recordit/server/util/RedisManager.java
@@ -1,0 +1,52 @@
+package com.recordit.server.util;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recordit.server.exception.redis.RedisParsingException;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisManager {
+
+	private static final String REDIS_PARSING_ERROR_MESSAGE = "Redis에서 Json을 파싱할 때 에러가 발생했습니다.";
+	private final StringRedisTemplate stringRedisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void set(@NonNull String key, @NonNull Object value) {
+		try {
+			stringRedisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(value));
+		} catch (JsonProcessingException e) {
+			throw new RedisParsingException(REDIS_PARSING_ERROR_MESSAGE);
+		}
+	}
+
+	public void set(@NonNull String key, @NonNull Object value, long timeout, @NonNull TimeUnit timeUnit) {
+		try {
+			stringRedisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(value), timeout, timeUnit);
+		} catch (JsonProcessingException e) {
+			throw new RedisParsingException(REDIS_PARSING_ERROR_MESSAGE);
+		}
+	}
+
+	public <T> Optional<T> get(@NonNull String key, Class<T> clazz) {
+		String jsonString = stringRedisTemplate.opsForValue().get(key);
+		if (!StringUtils.hasText(jsonString)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(objectMapper.readValue(jsonString, clazz));
+		} catch (JsonProcessingException e) {
+			throw new RedisParsingException(REDIS_PARSING_ERROR_MESSAGE);
+		}
+	}
+}

--- a/src/main/java/com/recordit/server/util/RedisManager.java
+++ b/src/main/java/com/recordit/server/util/RedisManager.java
@@ -38,7 +38,7 @@ public class RedisManager {
 		}
 	}
 
-	public <T> Optional<T> get(@NonNull String key, Class<T> clazz) {
+	public <T> Optional<T> get(@NonNull String key, @NonNull Class<T> clazz) {
 		String jsonString = stringRedisTemplate.opsForValue().get(key);
 		if (!StringUtils.hasText(jsonString)) {
 			return Optional.empty();

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -1,0 +1,62 @@
+package com.recordit.server.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.recordit.server.exception.member.DuplicateNicknameException;
+import com.recordit.server.repository.MemberRepository;
+import com.recordit.server.service.oauth.OauthServiceLocator;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@Mock
+	private OauthServiceLocator oauthServiceLocator;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Nested
+	@DisplayName("닉네임 중복 확인 기능에서 닉네임이")
+	class 닉네임_중복_확인_기능에서_닉네임이 {
+
+		@Test
+		@DisplayName("중복되면 예외를 던진다")
+		void 중복되면_예외를_던진다() {
+			// given
+			String nickname = "test";
+
+			given(memberRepository.existsByNickname(anyString()))
+					.willReturn(true);
+
+			// when, then
+			assertThatThrownBy(() -> memberService.isDuplicateNickname(nickname))
+					.isInstanceOf(DuplicateNicknameException.class);
+		}
+
+		@Test
+		@DisplayName("중복되지 않으면 예외를 던지지 않는다")
+		void 중복되지_않으면_예외를_던지지_않는다() {
+			// given
+			String nickname = "test";
+
+			given(memberRepository.existsByNickname(anyString()))
+					.willReturn(false);
+
+			// when, then
+			assertThatCode(() -> memberService.isDuplicateNickname(nickname))
+					.doesNotThrowAnyException();
+		}
+	}
+}

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -3,16 +3,30 @@ package com.recordit.server.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.recordit.server.constant.LoginType;
+import com.recordit.server.domain.Member;
+import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.RegisterRequestDto;
+import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
+import com.recordit.server.exception.member.NotFoundRegisterSessionException;
 import com.recordit.server.repository.MemberRepository;
+import com.recordit.server.service.oauth.OauthService;
 import com.recordit.server.service.oauth.OauthServiceLocator;
 import com.recordit.server.util.RedisManager;
 import com.recordit.server.util.SessionUtil;
@@ -33,18 +47,153 @@ public class MemberServiceTest {
 	private SessionUtil sessionUtil;
 
 	@Mock
-	RedisManager redisManager;
+	private RedisManager redisManager;
+
+	@Mock
+	private Member mockMember;
+
+	private MockedStatic<UUID> mockUUID;
+
+	private final String loginType = Arrays.stream(LoginType.values())
+			.findFirst()
+			.get().name();
+
+	private final UUID testUUID = UUID.randomUUID();
+
+	private final String mockOauthId = "testOauthId";
+	private final String nickname = "testNickname";
+
+	@BeforeEach
+	void init() {
+		mockUUID = mockStatic(UUID.class);
+	}
+
+	@AfterEach
+	void afterEach() {
+		mockUUID.close();
+	}
 
 	@Nested
-	@DisplayName("닉네임 중복 확인 기능에서 닉네임이")
+	@DisplayName("oauth 로그인을 할 때")
+	class oauth_로그인을_할_때_oauthToken을_통해_찾은_사용자가 {
+
+		@Nested
+		@DisplayName("oauthToken을 통해 찾은 사용자가")
+		class oauthToken을_통해_찾은_사용자가 {
+
+			@Mock
+			private OauthService oauthService;
+
+			private final String mockOauthToken = "testOauthToken";
+
+			private final LoginRequestDto loginRequestDto = LoginRequestDto.builder()
+					.oauthToken(mockOauthToken)
+					.build();
+
+			@Test
+			@DisplayName("있으면 null을 반환한다")
+			void 있으면_null을_반환한다() {
+				// given
+				Optional<Member> mockMember = Optional.of(MemberServiceTest.this.mockMember);
+
+				given(oauthServiceLocator.getOauthServiceByLoginType(anyString()))
+						.willReturn(oauthService);
+				given(oauthService.request(anyString()))
+						.willReturn(mockOauthId);
+				given(memberRepository.findByOauthId(mockOauthId))
+						.willReturn(mockMember);
+
+				// when
+				Optional<RegisterSessionResponseDto> result = memberService.oauthLogin(
+						loginType,
+						loginRequestDto
+				);
+
+				// then
+				assertThat(result.isEmpty()).isTrue();
+			}
+
+			@Test
+			@DisplayName("없으면 registerSessionUUID를 반환한다")
+			void 없으면_registerSessionUUID를_반환한다() {
+				// given
+				given(oauthServiceLocator.getOauthServiceByLoginType(anyString()))
+						.willReturn(oauthService);
+				given(oauthService.request(anyString()))
+						.willReturn(mockOauthId);
+				given(memberRepository.findByOauthId(mockOauthId))
+						.willReturn(Optional.empty());
+				given(UUID.randomUUID())
+						.willReturn(testUUID);
+
+				// when
+				Optional<RegisterSessionResponseDto> result = memberService.oauthLogin(
+						loginType,
+						loginRequestDto
+				);
+
+				// then
+				assertThat(result.isPresent()).isTrue();
+				assertThat(result.get().getRegisterSession()).isEqualTo(testUUID.toString());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("oauth 회원가입을 할 때")
+	class oauth_회원가입을_할_때 {
+
+		@Nested
+		@DisplayName("Redis에 RegisterSession이")
+		class Redis에_RegisterSession이 {
+
+			private RegisterRequestDto registerRequestDto = RegisterRequestDto.builder()
+					.registerSession(testUUID.toString())
+					.nickname(nickname)
+					.build();
+
+			@Test
+			@DisplayName("없으면 예외를 던진다")
+			void 없으면_예외를_던진다() {
+				// given
+				given(redisManager.get(anyString(), any()))
+						.willReturn(Optional.empty());
+
+				// when, then
+				assertThatThrownBy(() -> memberService.oauthRegister(
+						loginType,
+						registerRequestDto
+				)).isInstanceOf(NotFoundRegisterSessionException.class);
+
+			}
+
+			@Test
+			@DisplayName("있으면 예외를 던지지 않는다")
+			void 있으면_예외를_던지지_않는다() {
+				// given
+				given(redisManager.get(anyString(), any()))
+						.willReturn(Optional.of(mockOauthId));
+				given(memberRepository.existsByNickname(anyString()))
+						.willReturn(false);
+				given(memberRepository.save(any())).willReturn(mockMember);
+				willDoNothing().given(sessionUtil).saveUserIdInSession(anyLong());
+
+				// when, then
+				assertThatCode(() -> memberService.oauthRegister(loginType, registerRequestDto))
+						.doesNotThrowAnyException();
+			}
+
+		}
+	}
+
+	@Nested
+	@DisplayName("닉네임 중복 확인 기능에서")
 	class 닉네임_중복_확인_기능에서_닉네임이 {
 
 		@Test
 		@DisplayName("중복되면 예외를 던진다")
 		void 중복되면_예외를_던진다() {
 			// given
-			String nickname = "test";
-
 			given(memberRepository.existsByNickname(anyString()))
 					.willReturn(true);
 
@@ -57,8 +206,6 @@ public class MemberServiceTest {
 		@DisplayName("중복되지 않으면 예외를 던지지 않는다")
 		void 중복되지_않으면_예외를_던지지_않는다() {
 			// given
-			String nickname = "test";
-
 			given(memberRepository.existsByNickname(anyString()))
 					.willReturn(false);
 

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.recordit.server.exception.member.DuplicateNicknameException;
 import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthServiceLocator;
+import com.recordit.server.util.RedisManager;
+import com.recordit.server.util.SessionUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
@@ -26,6 +28,12 @@ public class MemberServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private SessionUtil sessionUtil;
+
+	@Mock
+	RedisManager redisManager;
 
 	@Nested
 	@DisplayName("닉네임 중복 확인 기능에서 닉네임이")


### PR DESCRIPTION
## 관련 이슈 번호

[BE-29 / 로그인/회원가입 요구사항에 따른 테스트코드 및 기능 구현](https://recodeit.atlassian.net/browse/BE-29)

## 설명
- FEAT: DTO 클래스에 빌더 추가
- FEAT: RedisManager 추가
   - RedisConfiguration에서 기존의 RedisTemplate를 StringRedisTemplate로 변경
   - Redis에서 읽거나 쓸 때 Parsing 예외 추가
- FEAT: 닉네임 중복 기능
   - 테스트 코드 작성
   - 기능 구현
- REFACTOR: OauthService의 request() 메소드의 return Type 변경 
- BUG: Member 클래스의 of 메소드에 누락된 username 추가
- FEAT: oauthLogin 기능
   - 테스트 코드 작성
   - RegisterSessionConstants를 추가하여 상수 관리
   - 기능 구현
- FEAT: oauthRegister 기능
   - 테스트 코드 작성
   - 기능 구현 
- Setting: Static Method 테스트를 위한 mockito-inline dependency 추가

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
