### PR TITLE
[BE-73] GoogleOauthService 구현

### DIFF
--- a/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/GoogleOauthService.java
@@ -1,18 +1,75 @@
 package com.recordit.server.service.oauth;
 
+import static com.recordit.server.constant.OauthConstants.*;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.recordit.server.constant.LoginType;
+import com.recordit.server.dto.member.GoogleAccessTokenResponseDto;
+import com.recordit.server.dto.member.GoogleUserInfoResponseDto;
+import com.recordit.server.environment.GoogleOauthProperties;
+import com.recordit.server.util.CustomObjectMapper;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class GoogleOauthService implements OauthService {
+
+	private final GoogleOauthProperties googleOauthProperties;
+
 	@Override
+	@Transactional(readOnly = true)
 	public LoginType getLoginType() {
 		return LoginType.GOOGLE;
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public String getUserInfoByOauthToken(String oauthToken) {
-		return null;
+		GoogleAccessTokenResponseDto googleAccessTokenResponseDto = requestAccessToken(oauthToken);
+		GoogleUserInfoResponseDto googleUserInfoResponseDto = requestUserInfo(googleAccessTokenResponseDto);
+		return googleUserInfoResponseDto.getSub();
+	}
+
+	@Transactional(readOnly = true)
+	protected GoogleAccessTokenResponseDto requestAccessToken(String oauthToken) {
+		String params = UriComponentsBuilder.fromUriString(googleOauthProperties.getTokenRequestUrl())
+				.queryParam(CODE.key, oauthToken)
+				.queryParam(CLIENT_ID.key, googleOauthProperties.getClientId())
+				.queryParam(CLIENT_SECRET.key, googleOauthProperties.getClientSecret())
+				.queryParam(REDIRECT_URI.key, googleOauthProperties.getRedirectUrl())
+				.queryParam(GRANT_TYPE.key, getFixGrantType())
+				.toUriString();
+
+		ResponseEntity<String> exchange = new RestTemplate().exchange(
+				params,
+				HttpMethod.POST,
+				null,
+				String.class
+		);
+
+		return CustomObjectMapper.readValue(exchange.getBody(), GoogleAccessTokenResponseDto.class);
+	}
+
+	@Transactional(readOnly = true)
+	protected GoogleUserInfoResponseDto requestUserInfo(GoogleAccessTokenResponseDto googleAccessTokenResponseDto) {
+		String uri = UriComponentsBuilder.fromUriString(googleOauthProperties.getUserInfoRequestUrl())
+				.queryParam(ID_TOKEN.key, googleAccessTokenResponseDto.getIdToken())
+				.toUriString();
+
+		ResponseEntity<String> exchange = new RestTemplate().exchange(
+				uri,
+				HttpMethod.GET,
+				null,
+				String.class
+		);
+
+		return CustomObjectMapper.readValue(exchange.getBody(), GoogleUserInfoResponseDto.class);
 	}
 }

--- a/src/test/java/com/recordit/server/service/oauth/GoogleOauthServiceTest.java
+++ b/src/test/java/com/recordit/server/service/oauth/GoogleOauthServiceTest.java
@@ -1,0 +1,35 @@
+package com.recordit.server.service.oauth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.recordit.server.constant.LoginType;
+import com.recordit.server.environment.GoogleOauthProperties;
+
+@ExtendWith(MockitoExtension.class)
+public class GoogleOauthServiceTest {
+
+	@InjectMocks
+	private GoogleOauthService googleOauthService;
+
+	@Mock
+	private GoogleOauthProperties googleOauthProperties;
+
+	@Test
+	@DisplayName("LoginType이 정상적으로 응답되는지 테스트한다")
+	void LoginType이_정상적으로_응답되는지_테스트한다() {
+		// given
+
+		// when
+		LoginType loginType = googleOauthService.getLoginType();
+
+		// then
+		assertThat(loginType).isEqualTo(LoginType.GOOGLE);
+	}
+}


### PR DESCRIPTION
## 관련 이슈 번호

[BE-73 / GoogleOauthService 구현](https://recodeit.atlassian.net/browse/BE-73)

## 설명
- GoogleOauthService 기능 구현
- GoogleOauthService 테스트 코드 작성

## 변경사항
- [x] requestAccessToken 기능 구현
- [x] requestUserInfo 기능 구현

## 질문사항
