### PR TITLE
[BE-74] KakaoOauthService 구현

### DIFF
--- a/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
+++ b/src/main/java/com/recordit/server/service/oauth/KakaoOauthService.java
@@ -1,18 +1,77 @@
 package com.recordit.server.service.oauth;
 
+import static com.recordit.server.constant.OauthConstants.*;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.recordit.server.constant.LoginType;
+import com.recordit.server.dto.member.KakaoAccessTokenResponseDto;
+import com.recordit.server.dto.member.KakaoUserInfoResponseDto;
+import com.recordit.server.environment.KakaoOauthProperties;
+import com.recordit.server.util.CustomObjectMapper;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class KakaoOauthService implements OauthService {
+
+	private final KakaoOauthProperties kakaoOauthProperties;
+
 	@Override
+	@Transactional(readOnly = true)
 	public LoginType getLoginType() {
 		return LoginType.KAKAO;
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public String getUserInfoByOauthToken(String oauthToken) {
-		return null;
+		KakaoAccessTokenResponseDto kakaoAccessTokenResponseDto = requestAccessToken(oauthToken);
+		KakaoUserInfoResponseDto kakaoUserInfoResponseDto = requestUserInfo(kakaoAccessTokenResponseDto);
+		return String.valueOf(kakaoUserInfoResponseDto.getId());
 	}
+
+	@Transactional(readOnly = true)
+	protected KakaoAccessTokenResponseDto requestAccessToken(String oauthToken) {
+		String params = UriComponentsBuilder.fromUriString(kakaoOauthProperties.getTokenRequestUrl())
+				.queryParam(CODE.key, oauthToken)
+				.queryParam(CLIENT_ID.key, kakaoOauthProperties.getClientId())
+				.queryParam(CLIENT_SECRET.key, kakaoOauthProperties.getClientSecret())
+				.queryParam(REDIRECT_URI.key, kakaoOauthProperties.getRedirectUrl())
+				.queryParam(GRANT_TYPE.key, getFixGrantType())
+				.toUriString();
+
+		ResponseEntity<String> exchange = new RestTemplate().exchange(
+				params,
+				HttpMethod.POST,
+				null,
+				String.class
+		);
+
+		return CustomObjectMapper.readValue(exchange.getBody(), KakaoAccessTokenResponseDto.class);
+	}
+
+	@Transactional(readOnly = true)
+	protected KakaoUserInfoResponseDto requestUserInfo(KakaoAccessTokenResponseDto kakaoAccessTokenResponseDto) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add(AUTHORIZATION.key, getFixPrefixJwt() + kakaoAccessTokenResponseDto.getAccessToken());
+
+		ResponseEntity<String> exchange = new RestTemplate().exchange(
+				kakaoOauthProperties.getUserInfoRequestUrl(),
+				HttpMethod.GET,
+				new HttpEntity(httpHeaders),
+				String.class
+		);
+
+		return CustomObjectMapper.readValue(exchange.getBody(), KakaoUserInfoResponseDto.class);
+	}
+
 }

--- a/src/test/java/com/recordit/server/service/oauth/KakaoOauthServiceTest.java
+++ b/src/test/java/com/recordit/server/service/oauth/KakaoOauthServiceTest.java
@@ -1,0 +1,35 @@
+package com.recordit.server.service.oauth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.recordit.server.constant.LoginType;
+import com.recordit.server.environment.KakaoOauthProperties;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoOauthServiceTest {
+
+	@InjectMocks
+	private KakaoOauthService kakaoOauthService;
+
+	@Mock
+	private KakaoOauthProperties kakaoOauthProperties;
+
+	@Test
+	@DisplayName("LoginType이 정상적으로 응답되는지 테스트한다")
+	void LoginType이_정상적으로_응답되는지_테스트한다() {
+		// given
+
+		// when
+		LoginType loginType = kakaoOauthService.getLoginType();
+
+		// then
+		assertThat(loginType).isEqualTo(LoginType.KAKAO);
+	}
+}


### PR DESCRIPTION
## 관련 이슈 번호

[BE-74 / KakaoOauthService 구현](https://recodeit.atlassian.net/browse/BE-74)

## 설명
- KakaoOauthService 기능 구현
- KakaoOauthService 테스트 코드 작성

## 변경사항
- [x] requestAccessToken 기능 구현
- [x] requestUserInfo 기능 구현

## 질문사항
