### PR TITLE
[BE-77] 카테고리 API 명세

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -1,0 +1,37 @@
+package com.recordit.server.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
+import com.recordit.server.repository.RecordCategoryRepository;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/record/category")
+public class RecordCategoryController {
+
+	private final RecordCategoryRepository recordCategoryRepository;
+
+	@ApiOperation(
+			value = "레코트 카테고리 전체 조회",
+			notes = "레코트 카테고리 전체를 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / 레코드 카테고리 목록 반환",
+					response = RecordCategoryResponseDto.class
+			)
+	})
+	@GetMapping
+	public ResponseEntity<?> getAllRecordCategories() {
+		return null;
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -1,0 +1,28 @@
+package com.recordit.server.dto.record.category;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@AllArgsConstructor
+@Builder
+public class RecordCategoryResponseDto {
+	@ApiModelProperty(notes = "레코드 카테고리 목록", required = true)
+	private HashMap<String, ArrayList<String>> recordCategory;
+}

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -1,7 +1,7 @@
 package com.recordit.server.dto.record.category;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -24,5 +24,5 @@ import lombok.ToString;
 @Builder
 public class RecordCategoryResponseDto {
 	@ApiModelProperty(notes = "레코드 카테고리 목록", required = true)
-	private HashMap<String, ArrayList<String>> recordCategory;
+	private Map<String, List<String>> recordCategory;
 }

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,9 +19,12 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@AllArgsConstructor
-@Builder
 public class RecordCategoryResponseDto {
 	@ApiModelProperty(notes = "레코드 카테고리 목록", required = true)
 	private Map<String, List<String>> recordCategory;
+
+	@Builder
+	public RecordCategoryResponseDto(Map<String, List<String>> recordCategory) {
+		this.recordCategory = recordCategory;
+	}
 }

--- a/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
@@ -1,0 +1,8 @@
+package com.recordit.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.recordit.server.domain.RecordCategory;
+
+public interface RecordCategoryRepository extends JpaRepository<RecordCategory, Long> {
+}

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -1,0 +1,14 @@
+package com.recordit.server.service;
+
+import org.springframework.stereotype.Service;
+
+import com.recordit.server.repository.RecordCategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RecordCategoryService {
+	private final RecordCategoryRepository recordCategoryRepository;
+
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-77 / 카테고리 API 명세](https://recodeit.atlassian.net/browse/BE-77)

## 설명
레코드 작성 시 카테고리 전체 목록을 조회하는 API 명세입니다.
카테고리 추가, 수정, 삭제는 기능 우선순위에 벗어나 추 후 작성 예정입니다

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] 카테고리 API Swagger 명세
- [x] RecordCategoryResponseDto 생성
- [x]  RecordCategoryController, RecordCategoryService, RecordCategoryRepository 생성
## 질문사항
