### PR TITLE
[BE-30] 레코드 작성, 레코드 조회

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
+import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.ErrorMessage;
 import com.recordit.server.service.RecordService;
 
@@ -47,12 +48,14 @@ public class RecordController {
 			)
 	})
 	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public ResponseEntity<?> writeRecord(
+	public ResponseEntity<WriteRecordResponseDto> writeRecord(
 			@ApiParam(required = true) @RequestPart(required = true) @Valid WriteRecordRequestDto writeRecordRequestDto,
 			@ApiParam @RequestPart(required = false) List<MultipartFile> files
 	) {
-		recordService.writeRecord(writeRecordRequestDto, files);
-		return new ResponseEntity<>(HttpStatus.CREATED);
+		return new ResponseEntity<>(
+				recordService.writeRecord(writeRecordRequestDto, files),
+				HttpStatus.CREATED
+		);
 	}
 
 	@ApiOperation(

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -52,10 +52,7 @@ public class RecordController {
 			@ApiParam(required = true) @RequestPart(required = true) @Valid WriteRecordRequestDto writeRecordRequestDto,
 			@ApiParam @RequestPart(required = false) List<MultipartFile> files
 	) {
-		return new ResponseEntity<>(
-				recordService.writeRecord(writeRecordRequestDto, files),
-				HttpStatus.CREATED
-		);
+		return ResponseEntity.status(HttpStatus.CREATED).body(recordService.writeRecord(writeRecordRequestDto, files));
 	}
 
 	@ApiOperation(

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -1,7 +1,10 @@
 package com.recordit.server.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,9 +49,10 @@ public class RecordController {
 	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<?> writeRecord(
 			@ApiParam(required = true) @RequestPart(required = true) @Valid WriteRecordRequestDto writeRecordRequestDto,
-			@ApiParam @RequestPart MultipartFile file
+			@ApiParam @RequestPart(required = false) List<MultipartFile> files
 	) {
-		return null;
+		recordService.writeRecord(writeRecordRequestDto, files);
+		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
 	@ApiOperation(
@@ -68,7 +72,7 @@ public class RecordController {
 	@GetMapping("/{recordId}")
 	public ResponseEntity<RecordDetailResponseDto> getDetailRecord(
 			@PathVariable("recordId") Long recordId) {
-		return null;
+		return ResponseEntity.ok().body(recordService.getDetailRecord(recordId));
 	}
 
 }

--- a/src/main/java/com/recordit/server/domain/Record.java
+++ b/src/main/java/com/recordit/server/domain/Record.java
@@ -13,6 +13,8 @@ import javax.persistence.OneToOne;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import com.recordit.server.dto.record.WriteRecordRequestDto;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,4 +56,40 @@ public class Record extends BaseEntity {
 	@JoinColumn(name = "RECORD_ICON_ID")
 	private RecordIcon recordIcon;
 
+	private Record(
+			RecordCategory recordCategory,
+			Member writer,
+			String title,
+			String content,
+			Integer numOfImage,
+			RecordColor recordColor,
+			RecordIcon recordIcon
+	) {
+		this.recordCategory = recordCategory;
+		this.writer = writer;
+		this.title = title;
+		this.content = content;
+		this.numOfImage = numOfImage;
+		this.recordColor = recordColor;
+		this.recordIcon = recordIcon;
+	}
+
+	public static Record of(
+			WriteRecordRequestDto writeRecordRequestDto,
+			RecordCategory recordCategory,
+			Member member,
+			Integer numOfImage,
+			RecordColor recordColor,
+			RecordIcon recordIcon
+	) {
+		return new Record(
+				recordCategory,
+				member,
+				writeRecordRequestDto.getTitle(),
+				writeRecordRequestDto.getContent(),
+				numOfImage,
+				recordColor,
+				recordIcon
+		);
+	}
 }

--- a/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.recordit.server.dto.record;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -20,19 +21,28 @@ import lombok.ToString;
 public class RecordDetailResponseDto {
 	private String title;
 	private String content;
-	private String hex;
+	private String writer;
+	private String colorName;
 	private String iconName;
 	private LocalDateTime createdAt;
-	private String imageUrl;
+	private List<String> imageUrls;
 
 	@Builder
-	public RecordDetailResponseDto(String title, String content, String hex, String iconName, LocalDateTime createdAt,
-			String imageUrl) {
+	public RecordDetailResponseDto(
+			String title,
+			String content,
+			String writer,
+			String colorName,
+			String iconName,
+			LocalDateTime createdAt,
+			List<String> imageUrls
+	) {
 		this.title = title;
 		this.content = content;
-		this.hex = hex;
+		this.writer = writer;
+		this.colorName = colorName;
 		this.iconName = iconName;
 		this.createdAt = createdAt;
-		this.imageUrl = imageUrl;
+		this.imageUrls = imageUrls;
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
@@ -19,6 +19,9 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecordDetailResponseDto {
+	private Long recordId;
+	private Long categoryId;
+	private String categoryName;
 	private String title;
 	private String content;
 	private String writer;
@@ -29,6 +32,9 @@ public class RecordDetailResponseDto {
 
 	@Builder
 	public RecordDetailResponseDto(
+			Long recordId,
+			Long categoryId,
+			String categoryName,
 			String title,
 			String content,
 			String writer,
@@ -37,6 +43,9 @@ public class RecordDetailResponseDto {
 			LocalDateTime createdAt,
 			List<String> imageUrls
 	) {
+		this.recordId = recordId;
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
 		this.title = title;
 		this.content = content;
 		this.writer = writer;

--- a/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
@@ -2,7 +2,6 @@ package com.recordit.server.dto.record;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -32,18 +31,24 @@ public class WriteRecordRequestDto {
 	@NotBlank(message = "레코드 내용은 빈 값일 수 없습니다.")
 	private String content;
 
-	@Pattern(regexp = "^#[A-Z0-9]{6}", message = "'#FFBF00'의 형태로 입력해 주세요.")
-	private String hex;
+	@NotBlank(message = "컬러 이름은 빈 값일 수 없습니다.")
+	private String colorName;
 
-	@NotBlank(message = "아이콘이름은 빈 값일 수 없습니다.")
+	@NotBlank(message = "아이콘 이름은 빈 값일 수 없습니다.")
 	private String iconName;
 
 	@Builder
-	public WriteRecordRequestDto(Long recordCategoryId, String title, String content, String hex, String iconName) {
+	public WriteRecordRequestDto(
+			Long recordCategoryId,
+			String title,
+			String content,
+			String colorName,
+			String iconName
+	) {
 		this.recordCategoryId = recordCategoryId;
 		this.title = title;
 		this.content = content;
-		this.hex = hex;
+		this.colorName = colorName;
 		this.iconName = iconName;
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/WriteRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordResponseDto.java
@@ -1,0 +1,25 @@
+package com.recordit.server.dto.record;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class WriteRecordResponseDto {
+	private Long recordId;
+
+	@Builder
+	public WriteRecordResponseDto(Long recordId) {
+		this.recordId = recordId;
+	}
+}

--- a/src/main/java/com/recordit/server/exception/member/MemberNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.member;
+
+public class MemberNotFoundException extends RuntimeException {
+	public MemberNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordColorNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordColorNotFoundException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record;
+
+public class RecordColorNotFoundException extends RuntimeException {
+	public RecordColorNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.recordit.server.exception.record;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.recordit.server.controller.RecordController;
+import com.recordit.server.exception.ErrorMessage;
+import com.recordit.server.exception.member.MemberNotFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice(basePackageClasses = RecordController.class)
+public class RecordExceptionHandler {
+	@ExceptionHandler(MemberNotFoundException.class)
+	public ResponseEntity<ErrorMessage> handleMemberNotFoundException(
+			MemberNotFoundException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+
+	@ExceptionHandler(RecordColorNotFoundException.class)
+	public ResponseEntity<ErrorMessage> handleRecordColorNotFoundException(
+			RecordColorNotFoundException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+
+	@ExceptionHandler(RecordNotFoundException.class)
+	public ResponseEntity<ErrorMessage> handleRecordNotFoundException(
+			RecordNotFoundException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+}
+

--- a/src/main/java/com/recordit/server/exception/record/RecordIconNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordIconNotFoundException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record;
+
+public class RecordIconNotFoundException extends RuntimeException {
+	public RecordIconNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordNotFoundException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record;
+
+public class RecordNotFoundException extends RuntimeException {
+	public RecordNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/category/RecordCategoryNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/category/RecordCategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record.category;
+
+public class RecordCategoryNotFoundException extends RuntimeException {
+	public RecordCategoryNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -1,0 +1,8 @@
+package com.recordit.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.recordit.server.domain.ImageFile;
+
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+}

--- a/src/main/java/com/recordit/server/repository/RecordColorRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordColorRepository.java
@@ -1,0 +1,11 @@
+package com.recordit.server.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.recordit.server.domain.RecordColor;
+
+public interface RecordColorRepository extends JpaRepository<RecordColor, Long> {
+	Optional<RecordColor> findByName(String colorName);
+}

--- a/src/main/java/com/recordit/server/repository/RecordIconRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordIconRepository.java
@@ -1,0 +1,11 @@
+package com.recordit.server.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.recordit.server.domain.RecordIcon;
+
+public interface RecordIconRepository extends JpaRepository<RecordIcon, Long> {
+	Optional<RecordIcon> findByName(String iconName);
+}

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -3,12 +3,11 @@ package com.recordit.server.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.Record;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
-	@Query("select r from RECORD r join fetch r.writer join fetch r.recordColor join fetch r.recordIcon"
-			+ " where r.id = :id")
+	// @Query("select r from RECORD r join fetch r.writer join fetch r.recordColor join fetch r.recordIcon"
+	// 		+ " where r.id = :id")
 	Optional<Record> findById(Long id);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,8 +1,14 @@
 package com.recordit.server.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.Record;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
+	@Query("select r from RECORD r join fetch r.writer join fetch r.recordColor join fetch r.recordIcon"
+			+ " where r.id = :id")
+	Optional<Record> findById(Long id);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,7 +1,5 @@
 package com.recordit.server.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.recordit.server.domain.Record;
@@ -9,5 +7,5 @@ import com.recordit.server.domain.Record;
 public interface RecordRepository extends JpaRepository<Record, Long> {
 	// @Query("select r from RECORD r join fetch r.writer join fetch r.recordColor join fetch r.recordIcon"
 	// 		+ " where r.id = :id")
-	Optional<Record> findById(Long id);
+	// Optional<Record> findById(Long id);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,13 +1,89 @@
 package com.recordit.server.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.recordit.server.domain.Member;
+import com.recordit.server.domain.Record;
+import com.recordit.server.domain.RecordCategory;
+import com.recordit.server.domain.RecordColor;
+import com.recordit.server.domain.RecordIcon;
+import com.recordit.server.dto.record.RecordDetailResponseDto;
+import com.recordit.server.dto.record.WriteRecordRequestDto;
+import com.recordit.server.exception.member.MemberNotFoundException;
+import com.recordit.server.exception.record.RecordColorNotFoundException;
+import com.recordit.server.exception.record.RecordIconNotFoundException;
+import com.recordit.server.exception.record.RecordNotFoundException;
+import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
+import com.recordit.server.repository.ImageFileRepository;
+import com.recordit.server.repository.MemberRepository;
+import com.recordit.server.repository.RecordCategoryRepository;
+import com.recordit.server.repository.RecordColorRepository;
+import com.recordit.server.repository.RecordIconRepository;
 import com.recordit.server.repository.RecordRepository;
+import com.recordit.server.util.SessionUtil;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class RecordService {
+	private final ImageFileRepository imageFileRepository;
+	private final SessionUtil sessionUtil;
+	private final MemberRepository memberRepository;
+	private final RecordCategoryRepository recordCategoryRepository;
+	private final RecordColorRepository recordColorRepository;
+	private final RecordIconRepository recordIconRepository;
 	private final RecordRepository recordRepository;
+
+	@Transactional
+	public void writeRecord(WriteRecordRequestDto writeRecordRequestDto, List<MultipartFile> files) {
+		List<String> urls = List.of();
+		// if (!file.isEmpty()) { // 파일 데이터가 존재할 때
+		// 	/* todo
+		// 		1.이미지 저장 후 url 가져오기
+		// 		2.imageFileRepository에 save
+		// 		3.numOfImage에 file 개수 대입 (개발 초기 단계에는 1개만 가능)
+		// 	 */
+		// }
+		sessionUtil.saveUserIdInSession(1L);
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+		RecordCategory recordCategory = recordCategoryRepository.findById(writeRecordRequestDto.getRecordCategoryId())
+				.orElseThrow(() -> new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다."));
+
+		RecordColor recordColor = recordColorRepository.findByName(writeRecordRequestDto.getColorName())
+				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
+
+		RecordIcon recordIcon = recordIconRepository.findByName(writeRecordRequestDto.getIconName())
+				.orElseThrow(() -> new RecordIconNotFoundException("아이콘 정보를 찾을 수 없습니다."));
+
+		Record record = Record.of(writeRecordRequestDto, recordCategory, member,
+				urls.size(), recordColor, recordIcon);
+		recordRepository.save(record);
+	}
+
+	@Transactional(readOnly = true)
+	public RecordDetailResponseDto getDetailRecord(Long recordId) {
+		Record record = recordRepository.findById(recordId)
+				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
+
+		List<String> imageUrls = List.of();
+		// List<String> urls = imageFileService.findByRecordId(record.getId(), record.getNumOfImage());
+
+		return RecordDetailResponseDto.builder()
+				.title(record.getTitle())
+				.content(record.getContent())
+				.writer(record.getWriter().getNickname())
+				.colorName(record.getRecordColor().getName())
+				.iconName(record.getRecordIcon().getName())
+				.createdAt(record.getCreatedAt())
+				.imageUrls(imageUrls)
+				.build();
+	}
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -13,6 +13,7 @@ import com.recordit.server.domain.RecordColor;
 import com.recordit.server.domain.RecordIcon;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
+import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.record.RecordColorNotFoundException;
 import com.recordit.server.exception.record.RecordIconNotFoundException;
@@ -40,7 +41,7 @@ public class RecordService {
 	private final RecordRepository recordRepository;
 
 	@Transactional
-	public void writeRecord(WriteRecordRequestDto writeRecordRequestDto, List<MultipartFile> files) {
+	public WriteRecordResponseDto writeRecord(WriteRecordRequestDto writeRecordRequestDto, List<MultipartFile> files) {
 		List<String> urls = List.of();
 		// if (!file.isEmpty()) { // 파일 데이터가 존재할 때
 		// 	/* todo
@@ -65,7 +66,12 @@ public class RecordService {
 
 		Record record = Record.of(writeRecordRequestDto, recordCategory, member,
 				urls.size(), recordColor, recordIcon);
-		recordRepository.save(record);
+
+		Long recordId = recordRepository.save(record).getId();
+
+		return WriteRecordResponseDto.builder()
+				.recordId(recordId)
+				.build();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -83,6 +83,9 @@ public class RecordService {
 		// List<String> urls = imageFileService.findByRecordId(record.getId(), record.getNumOfImage());
 
 		return RecordDetailResponseDto.builder()
+				.recordId(record.getId())
+				.categoryId(record.getRecordCategory().getId())
+				.categoryName(record.getRecordCategory().getName())
 				.title(record.getTitle())
 				.content(record.getContent())
 				.writer(record.getWriter().getNickname())


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-30 / 레코드 작성, 레코드 조회](https://recodeit.atlassian.net/browse/BE-30)
## 설명
레코드 작성과 레코드 조회 API 구현 하였습니다.
이미지 업로드 작업 시 RecordService에서 추가 해야합니다.

Entity에서 여러개의 컬럼이 FetchType.LAZY가 걸려있을 때
Fetch join을 사용하니 여러개가 중첩된 형태의 조인 쿼리가 날라가는걸 발견하였습니다.
Fetch join을 사용하지 않고 조회 vs Fetch join을 사용하고 조회
어떤것이 더 검색 성능이 좋을까가 궁금하여 테스트 해 본 결과
동일 id에 대한 반복테스트는 fetch join을 적용시킨것이 더 빨랐지만,
랜덤한 10개의 id에 대한 테스트는 fetch join을 적용시키지 않은 것이 더 빨랐기 때문에
fetch join 적용을 해제 하였습니다.

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] RecordExceptionHandler 정의
- [x] CustomException 생성
- [x] Record Entity 정적 팩토리 메서드로 객체 생성
- ~~Record에 지연로딩으로 되어있어 레코드 조회 시 쿼리가 계속 날라가서 패치조인 적용~~

## 질문사항
