### PR TITLE
[BE-91] GlobalExceptionHandler에 Validation 예외 추가

### DIFF
--- a/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.recordit.server.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorMessage> handleMethodArgumentNotValidException(
+			MethodArgumentNotValidException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-91 / GlobalExceptionHandler에 Validation 예외 추가](https://recodeit.atlassian.net/browse/BE-91)

## 설명
Validation 실패 시 발생하는 `MethodArgumentNotValidException`를 GalobalExceptionHandler를 생성하여
전역에서 예외처리를 해주도록 하였습니다.

예외 처리 하여 Validation 예외 시 아래와 같이 응답됩니다.
![image](https://user-images.githubusercontent.com/64088250/209915124-f7831a64-2398-4729-9b98-16d3450fd894.png)


## 변경사항
- [x] GlobalExceptionHandler 생성
- [x] MethodArgumentNotValidException 예외 처리 
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
