### PR TITLE
[BE-83] 회원가입 Request에 Validation 추가

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.recordit.server.controller;
 
 import java.util.Optional;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -87,7 +89,7 @@ public class MemberController {
 	@PostMapping("/oauth/register/{loginType}")
 	public ResponseEntity oauthRegister(
 			@ApiParam(allowableValues = "KAKAO, GOOGLE", required = true) @PathVariable("loginType") String loginType,
-			@RequestBody RegisterRequestDto registerRequestDto
+			@RequestBody @Valid RegisterRequestDto registerRequestDto
 	) {
 		memberService.oauthRegister(loginType, registerRequestDto);
 		return new ResponseEntity(HttpStatus.OK);

--- a/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
@@ -1,5 +1,7 @@
 package com.recordit.server.dto.member;
 
+import javax.validation.constraints.Pattern;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -22,6 +24,7 @@ public class RegisterRequestDto {
 	private String registerSession;
 
 	@ApiModelProperty(notes = "사용자 닉네임", required = true)
+	@Pattern(regexp = "[가-힣a-zA-z0-9]{2,10}")
 	private String nickname;
 
 	@Builder


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-83 / 회원가입 Request에 Validation 추가](https://recodeit.atlassian.net/browse/BE-83)

## 설명
```
- 닉네임
    - 글자수 제한
      최소 2자 ~ 최대 8자
    - 사용 글자
      한글, 영어(대소문자), 숫자 사용 가능
      특수문자, 띄어쓰기 불가능
    - 공백 제한
      앞, 뒤, 글자 사이 모두 공백 사용 불가
      ex) ‘ 태리 ‘ - X, ‘태 리’ - X
```
회원 가입 닉네임 정책에 따라 Validation을 추가하였습니다.

## 변경사항
- [x] RegisterRequestDto에 nickname 필드에 Pattern 추가
- [x] MemberController oauthRegister 메소드에 Valid 어노테이션 추가 
## 질문사항
