### PR TITLE
[BE-83] fix: regex nickname 2-10에서 2-8글자로 수정

### DIFF
--- a/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
@@ -24,7 +24,7 @@ public class RegisterRequestDto {
 	private String registerSession;
 
 	@ApiModelProperty(notes = "사용자 닉네임", required = true)
-	@Pattern(regexp = "[가-힣a-zA-z0-9]{2,10}")
+	@Pattern(regexp = "[가-힣a-zA-z0-9]{2,8}")
 	private String nickname;
 
 	@Builder


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-83 / 회원가입 Request에 Validation 추가](https://recodeit.atlassian.net/browse/BE-83)

## 설명
2-10 글자가 아닌 2-8로 변경
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
