### PR TITLE
[BE-95] 레코드 카테고리 전체 조회

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -1,5 +1,7 @@
 package com.recordit.server.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,11 +29,12 @@ public class RecordCategoryController {
 	@ApiResponses({
 			@ApiResponse(
 					code = 200, message = "API 정상 작동 / 레코드 카테고리 목록 반환",
-					response = RecordCategoryResponseDto.class
+					response = RecordCategoryResponseDto.class, responseContainer = "List"
 			)
 	})
 	@GetMapping
-	public ResponseEntity<?> getAllRecordCategories() {
-		return null;
+	public ResponseEntity<List<RecordCategoryResponseDto>> getAllRecordCategories() {
+		return ResponseEntity.ok(recordCategoryService.getAllRecordCategories());
 	}
+
 }

--- a/src/main/java/com/recordit/server/domain/RecordCategory.java
+++ b/src/main/java/com/recordit/server/domain/RecordCategory.java
@@ -1,5 +1,8 @@
 package com.recordit.server.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -34,4 +38,16 @@ public class RecordCategory extends BaseEntity {
 
 	@Column(name = "NAME")
 	private String name;
+
+	@OneToMany(mappedBy = "parentRecordCategory")
+	private List<RecordCategory> subcategories = new ArrayList<>();
+
+	private RecordCategory(RecordCategory parentRecordCategory, String name) {
+		this.parentRecordCategory = parentRecordCategory;
+		this.name = name;
+	}
+
+	public static RecordCategory of(RecordCategory parentRecordCategory, String name) {
+		return new RecordCategory(parentRecordCategory, name);
+	}
 }

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -1,10 +1,11 @@
 package com.recordit.server.dto.record.category;
 
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.recordit.server.domain.RecordCategory;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -20,11 +21,27 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecordCategoryResponseDto {
-	@ApiModelProperty(notes = "레코드 카테고리 목록", required = true)
-	private Map<String, List<String>> recordCategory;
+
+	@ApiModelProperty(notes = "레코드 카테고리 ID", required = true)
+	private Long id;
+
+	@ApiModelProperty(notes = "레코드 카테고리 이름", required = true)
+	private String name;
+
+	@ApiModelProperty(notes = "하위 레코드 목록", required = true)
+	private List<RecordCategoryResponseDto> subcategories;
 
 	@Builder
-	public RecordCategoryResponseDto(Map<String, List<String>> recordCategory) {
-		this.recordCategory = recordCategory;
+	public RecordCategoryResponseDto(Long id, String name, List<RecordCategory> subcategories) {
+		this.id = id;
+		this.name = name;
+		this.subcategories = subcategories.stream().map(
+				subcategory -> RecordCategoryResponseDto.builder()
+						.id(subcategory.getId())
+						.name(subcategory.getName())
+						.subcategories(subcategory.getSubcategories())
+						.build()
+		).collect(Collectors.toList());
 	}
+
 }

--- a/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
@@ -1,8 +1,14 @@
 package com.recordit.server.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.RecordCategory;
 
 public interface RecordCategoryRepository extends JpaRepository<RecordCategory, Long> {
+
+	@Query("select rc from RECORD_CATEGORY rc left join fetch rc.subcategories")
+	List<RecordCategory> findAll();
 }

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -1,7 +1,12 @@
 package com.recordit.server.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
 import com.recordit.server.repository.RecordCategoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -11,4 +16,16 @@ import lombok.RequiredArgsConstructor;
 public class RecordCategoryService {
 	private final RecordCategoryRepository recordCategoryRepository;
 
+	@Transactional(readOnly = true)
+	public List<RecordCategoryResponseDto> getAllRecordCategories() {
+		return recordCategoryRepository.findAll().stream()
+				.filter(recordCategory -> recordCategory.getParentRecordCategory() == null)
+				.map(
+						recordCategory -> RecordCategoryResponseDto.builder()
+								.id(recordCategory.getId())
+								.name(recordCategory.getName())
+								.subcategories(recordCategory.getSubcategories())
+								.build()
+				).collect(Collectors.toList());
+	}
 }

--- a/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
@@ -1,0 +1,65 @@
+package com.recordit.server.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.recordit.server.domain.RecordCategory;
+import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
+import com.recordit.server.repository.RecordCategoryRepository;
+
+@ExtendWith({MockitoExtension.class})
+class RecordCategoryServiceTest {
+
+	@InjectMocks
+	private RecordCategoryService recordCategoryService;
+
+	@Mock
+	private RecordCategoryRepository recordCategoryRepository;
+
+	@Test
+	@DisplayName("레코드 전제 조회를 테스트한다")
+	void 레코드_전제_조회를_테스트한다() {
+		// given
+		RecordCategory recordCategory1 = mock(RecordCategory.class);
+		RecordCategory recordCategory2 = mock(RecordCategory.class);
+		RecordCategory recordCategory3 = mock(RecordCategory.class);
+
+		given(recordCategory1.getId())
+				.willReturn(1L);
+		given(recordCategory1.getName())
+				.willReturn("recordCategory1");
+		given(recordCategory1.getSubcategories())
+				.willReturn(List.of(recordCategory2));
+
+		given(recordCategory2.getId())
+				.willReturn(2L);
+		given(recordCategory2.getName())
+				.willReturn("recordCategory2");
+
+		given(recordCategory3.getId())
+				.willReturn(3L);
+		given(recordCategory3.getName())
+				.willReturn("recordCategory3");
+
+		given(recordCategoryRepository.findAll())
+				.willReturn(List.of(recordCategory1, recordCategory3));
+		// when
+		List<RecordCategoryResponseDto> result = recordCategoryService.getAllRecordCategories();
+
+		// then
+		assertThat(result.size()).isEqualTo(2);
+		assertThat(result.get(0).getSubcategories().size()).isEqualTo(1);
+		assertThat(result.get(0).getSubcategories().get(0).getId()).isEqualTo(2L);
+		assertThat(result.get(1).getId()).isEqualTo(3L);
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈 번호

[BE-95 / 레코드 카테고리 전체 조회](https://recodeit.atlassian.net/browse/BE-95)

## 설명
- 레코드 카테고리 전체 조회 관련 API 명세 수정
- RecordCategory Entity에 정적 팩토리 메소드, 양방향 매핑 추가
- 전체 레코드 조회 기능 추가
   - RecordRepository에서 레코드 전체 조회시 fetch join 적용
   - 관련 테스트 코드 추가

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
