### PR TITLE
[BE-96] FE요청으로 인해 닉네임 중복 API 응답값 설정

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
+import com.recordit.server.exception.member.DuplicateNicknameException;
 import com.recordit.server.service.MemberService;
 
 import io.swagger.annotations.ApiOperation;
@@ -100,13 +101,17 @@ public class MemberController {
 			notes = "닉네임을 받아 해당 닉네임이 중복되었는지 판별"
 	)
 	@ApiResponses({
-			@ApiResponse(code = 200, message = "닉네임이 사용 가능한 경우"),
-			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우")
+			@ApiResponse(code = 200, message = "닉네임이 사용 가능한 경우 true 반환", response = Boolean.class),
+			@ApiResponse(code = 409, message = "닉네임이 중복 된 경우 false 반환")
 	})
 	@GetMapping("/nickname")
 	public ResponseEntity duplicateNicknameCheck(@RequestParam String nickname) {
-		memberService.isDuplicateNickname(nickname);
-		return new ResponseEntity(HttpStatus.OK);
+		try {
+			memberService.isDuplicateNickname(nickname);
+		} catch (DuplicateNicknameException e) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(false);
+		}
+		return ResponseEntity.status(HttpStatus.OK).body(true);
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈 번호

[BE-96 / FE요청으로 인해 닉네임 중복 API 응답값 설정](https://recodeit.atlassian.net/browse/BE-96)

## 설명
- FE 요청으로 닉네임 중복 API 응답값을 Boolean 형태로 추가

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
