### PR TITLE
[BE-100] redis cache config 생성

### DIFF
--- a/src/main/java/com/recordit/server/configuration/CacheConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/CacheConfiguration.java
@@ -1,0 +1,40 @@
+package com.recordit.server.configuration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfiguration {
+
+	@Bean
+	public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+		RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+				.disableCachingNullValues()
+				.prefixCacheNameWith("cache:")
+				.serializeKeysWith(
+						RedisSerializationContext
+								.SerializationPair
+								.fromSerializer(new StringRedisSerializer())
+				)
+				.serializeValuesWith(
+						RedisSerializationContext
+								.SerializationPair
+								.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class))
+				);
+
+		return RedisCacheManager.RedisCacheManagerBuilder
+				.fromConnectionFactory(redisConnectionFactory)
+				.cacheDefaults(configuration)
+				.build();
+	}
+}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-100 / redis cache config 생성](https://recodeit.atlassian.net/browse/BE-100)

## 설명
Redis를 Cache 용도로 사용하기 위해 redis cache config 생성하였습니다.
TTL은 따로 설정 안해두었습니다

## 변경사항
- [x] Redis Cache Configuration 생성

## 질문사항
