### PR TITLE
[BE-105] 전체 카테고리 조회시 조회 순서 지정

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -2,8 +2,8 @@ package com.recordit.server.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -26,10 +26,12 @@ public class RecordCategoryService {
 	public List<RecordCategoryResponseDto> getAllRecordCategories() {
 		List<RecordCategory> findRecordCategories = recordCategoryRepository.findAllFetchDepthIsOne();
 
+		LinkedHashMap<RecordCategory, List<RecordCategory>> parentToChildren = new LinkedHashMap<>();
+
 		// 부모이면서 자식이 null이 아닌 Map 생성
-		Map<RecordCategory, List<RecordCategory>> parentToChildren = findRecordCategories.stream()
+		parentToChildren.putAll(findRecordCategories.stream()
 				.filter(recordCategory -> recordCategory.getParentRecordCategory() != null)
-				.collect(Collectors.groupingBy(RecordCategory::getParentRecordCategory));
+				.collect(Collectors.groupingBy(RecordCategory::getParentRecordCategory)));
 
 		// 부모이면서 자식이 null인 객체 Map에 추가
 		findRecordCategories.stream()

--- a/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
@@ -26,8 +26,8 @@ class RecordCategoryServiceTest {
 	private RecordCategoryRepository recordCategoryRepository;
 
 	@Test
-	@DisplayName("레코드 전제 조회를 테스트한다")
-	void 레코드_전제_조회를_테스트한다() {
+	@DisplayName("레코드 카테고리 전체 조회를 테스트한다")
+	void 레코드_카테고리_전체_조회를_테스트한다() {
 		// given
 		RecordCategory recordCategory1 = mock(RecordCategory.class);
 		RecordCategory recordCategory2 = mock(RecordCategory.class);


### PR DESCRIPTION
## 관련 이슈 번호

[BE-105 / 전체 카테고리 조회시 조회 순서 지정](https://recodeit.atlassian.net/browse/BE-105)

## 설명
- 레코드 카테고리 전체 조회시 nullLast로 순서 지정
- 관련 테스트 코드 오타 수정

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
