### PR TITLE
[BE-109] fix: 로그 ResponseBody에 UTF-8 설정

### DIFF
--- a/src/main/java/com/recordit/server/logger/HTTPLogFilter.java
+++ b/src/main/java/com/recordit/server/logger/HTTPLogFilter.java
@@ -109,6 +109,7 @@ public class HTTPLogFilter implements Filter {
 				ContentCachingResponseWrapper.class
 		);
 		if (wrapper != null) {
+			wrapper.setCharacterEncoding("UTF-8");
 			byte[] buf = wrapper.getContentAsByteArray();
 			if (buf.length > 0) {
 				payload = new String(buf, 0, buf.length, wrapper.getCharacterEncoding());


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-109 / 로그 ResponseBody에 UTF-8 설정](https://recodeit.atlassian.net/browse/BE-109)

## 설명
로그 내용 중 ResponseBody에 UTF-8 설정이 누락되어 깨지는 현상이 발생하여 UTF-8설정을 추가하였습니다

## 변경사항
- [x] HTTPLogfilter.java 파일 `wrapper.setCharacterEncoding("UTF-8");` 설정 추가

## 질문사항
