### PR TITLE
[BE-122] SameSite 정책으로 인해 Set-Cookie가 안되는 버그

### DIFF
--- a/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
@@ -1,5 +1,6 @@
 package com.recordit.server.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -11,11 +12,13 @@ import com.recordit.server.converter.LoginTypeConverter;
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
 	private final long MAX_AGE_SECS = 3000;
+	@Value("${cors.origin}")
+	private String originPattern;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-				.allowedOriginPatterns("*")
+				.allowedOriginPatterns(originPattern)
 				.allowedMethods("*")
 				.allowedHeaders("*")
 				.allowCredentials(true)

--- a/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
@@ -12,8 +12,14 @@ import com.recordit.server.converter.LoginTypeConverter;
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
 	private final long MAX_AGE_SECS = 3000;
-	@Value("${cors.origin}")
-	private String originPattern;
+
+	private final String originPattern;
+
+	public WebMvcConfiguration(
+			@Value("${cors.origin}") String originPattern
+	) {
+		this.originPattern = originPattern;
+	}
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/comment")
+@RequestMapping("/api/comment")
 public class CommentController {
 
 	private final CommentService commentService;

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member")
+@RequestMapping("/api/member")
 public class MemberController {
 
 	private final MemberService memberService;

--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/record/category")
+@RequestMapping("/api/record/category")
 public class RecordCategoryController {
 
 	private final RecordCategoryService recordCategoryService;

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/record")
+@RequestMapping("/api/record")
 public class RecordController {
 
 	private final RecordService recordService;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,9 +28,5 @@ springfox:
       use-model-v3: false
 logging:
   config: classpath:log4j2-dev.xml
-server:
-  servlet:
-    session:
-      cookie:
-        same-site: none
-        secure: true
+cors:
+  origin: ${CORS_ORIGIN_NAME:}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,5 @@ springfox:
       use-model-v3: false
 logging:
   config: classpath:log4j2-local.xml
+cors:
+  origin: ${CORS_ORIGIN_NAME:}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,3 +47,6 @@ s3:
   bucket: ${S3_BUCKET_NAME:}
   directory: ${S3_DIRECTORY_NAME:}
   region: ap-northeast-2
+
+cors:
+  origin: ${CORS_ORIGIN_NAME:}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-122 / SameSite 정책으로 인해 Set-Cookie가 안되는 버그](https://recodeit.atlassian.net/browse/BE-122) 

## 설명
SameSite 정책으로 인해 Set-Cookie가 안되는 버그가 발생하였습니다.
NGINX 설정을 하여 프론트와 백엔드를 같은 origin으로 변경하였고,
그에 따른 originPattern을 변경하였습니다
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
- [x] CORS_ORIGIN_NAME 환경변수로 관리 (LOCAL에서 작업 시 환경변수 추가해주세용)
- [x] 모든 Controller RequestMapping에 /api를 prefix에 추가
## 질문사항


[BE-122]: https://recodeit.atlassian.net/browse/BE-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BE-122]: https://recodeit.atlassian.net/browse/BE-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ