### PR TITLE
[BE-123] 글 작성 시 세션 정보 이용하여 글 작성자를 닉네임으로 설정

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -52,7 +52,7 @@ public class RecordService {
 		// 		3.numOfImage에 file 개수 대입 (개발 초기 단계에는 1개만 가능)
 		// 	 */
 		// }
-		sessionUtil.saveUserIdInSession(1L);
+
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-123 / 글 작성 시 세션 정보 이용하여 글 작성자를 닉네임으로 설정](https://recodeit.atlassian.net/browse/BE-123)

## 설명
기존 로그인이 진행되지 않아 고정 값으로 1번 회원의 정보를 글 작성자로 두었던 코드를
로그인이 정상적으로 진행되어 세션에서 받아온 값으로 세팅해주었습니다.

## 변경사항
- [x] RecordService.java에서 `sessionUtil.saveUserIdInSession(1L);` 삭제

## 질문사항


[BE-123]: https://recodeit.atlassian.net/browse/BE-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BE-123]: https://recodeit.atlassian.net/browse/BE-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ