### PR TITLE
[BE-125] 닉네임 중복 체크 API 응답값을 "닉네임 중복시 true로 반환"하게 바꾸기

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -110,9 +110,9 @@ public class MemberController {
 		try {
 			memberService.isDuplicateNickname(nickname);
 		} catch (DuplicateNicknameException e) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).body(false);
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(true);
 		}
-		return ResponseEntity.status(HttpStatus.OK).body(true);
+		return ResponseEntity.status(HttpStatus.OK).body(false);
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈 번호

[BE-125 / 닉네임 중복 체크 API 응답값을 "닉네임 중복시 true로 반환"하게 바꾸기](https://recodeit.atlassian.net/browse/BE-125)

## 설명
- 기존에 닉네임 중복시 false를 반환하던걸 반대로 true를 반환하도록 변경함

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
