### PR TITLE
[BE-133] 저장된 세션 Serializer 때문에 Member ID 안보이는 버그 해결

### DIFF
--- a/src/main/java/com/recordit/server/configuration/RedisConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/RedisConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -38,10 +40,14 @@ public class RedisConfiguration {
 	@Bean
 	public StringRedisTemplate redisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		StringRedisTemplate redisTemplate = new StringRedisTemplate();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
-		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		return redisTemplate;
 	}
 
+	@Bean
+	public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+		return new Jackson2JsonRedisSerializer<Object>(Object.class);
+	}
 }


### PR DESCRIPTION
## 관련 이슈 번호

[BE-133 / 저장된 세션 Serializer 때문에 Member ID 안보이는 버그 해결](https://recodeit.atlassian.net/browse/BE-133)

## 설명
- Redis Session 저장할 때 Serializer를 Jackson2로 변경

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
