### PR TITLE
[BE-121] 레코드 작성, 조회시 이미지가 DB에 반영되는 기능 추가

### DIFF
--- a/src/main/java/com/recordit/server/exception/record/RecordImageNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordImageNotFoundException.java
@@ -1,0 +1,8 @@
+package com.recordit.server.exception.record;
+
+public class RecordImageNotFoundException extends RuntimeException {
+
+	public RecordImageNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordImageNotFoundException.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordImageNotFoundException.java
@@ -1,8 +1,0 @@
-package com.recordit.server.exception.record;
-
-public class RecordImageNotFoundException extends RuntimeException {
-
-	public RecordImageNotFoundException(String message) {
-		super(message);
-	}
-}

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -9,7 +9,6 @@ import com.recordit.server.constant.RefType;
 import com.recordit.server.domain.ImageFile;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
-
 	Optional<List<ImageFile>> findByRefIdAndRefType(Long refId, RefType refType);
 
 }

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -1,8 +1,15 @@
 package com.recordit.server.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.recordit.server.domain.ImageFile;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+	@Query("SELECT i.downloadUrl FROM IMAGE_FILE i WHERE i.refId = :refId")
+	Optional<List<String>> findDownloadUrls(@Param("refId") Long recordId);
 }

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -4,12 +4,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import com.recordit.server.constant.RefType;
 import com.recordit.server.domain.ImageFile;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
-	@Query("SELECT i.downloadUrl FROM IMAGE_FILE i WHERE i.refId = :refId")
-	Optional<List<String>> findDownloadUrls(@Param("refId") Long recordId);
+
+	Optional<List<ImageFile>> findByRefIdAndRefType(Long refId, RefType refType);
+
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,6 +1,9 @@
 package com.recordit.server.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.Record;
 
@@ -8,4 +11,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	// @Query("select r from RECORD r join fetch r.writer join fetch r.recordColor join fetch r.recordIcon"
 	// 		+ " where r.id = :id")
 	// Optional<Record> findById(Long id);
+
+	@Query("SELECT MAX(r.id) FROM RECORD r")
+	Optional<Long> findLatestRecordId();
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,9 +1,6 @@
 package com.recordit.server.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.Record;
 
@@ -12,6 +9,4 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	// 		+ " where r.id = :id")
 	// Optional<Record> findById(Long id);
 
-	@Query("SELECT MAX(r.id) FROM RECORD r")
-	Optional<Long> findLatestRecordId();
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,5 +1,6 @@
 package com.recordit.server.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.constant.RefType;
+import com.recordit.server.domain.ImageFile;
 import com.recordit.server.domain.Member;
 import com.recordit.server.domain.Record;
 import com.recordit.server.domain.RecordCategory;
@@ -19,6 +21,7 @@ import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.record.RecordColorNotFoundException;
 import com.recordit.server.exception.record.RecordIconNotFoundException;
+import com.recordit.server.exception.record.RecordImageNotFoundException;
 import com.recordit.server.exception.record.RecordNotFoundException;
 import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
 import com.recordit.server.repository.ImageFileRepository;
@@ -100,10 +103,23 @@ public class RecordService {
 
 		List<String> imageUrls = List.of();
 
-		Optional<List<String>> optionalStrings = imageFileRepository.findDownloadUrls(recordId);
-		if (!optionalStrings.isEmpty()) {
+		List<ImageFile> imageFileList = imageFileRepository
+				.findByRefIdAndRefType(recordId, RefType.RECORD)
+				.orElseThrow(() -> new RecordImageNotFoundException("레코드의 이미지가 존재하지 않습니다."));
+
+		List<String> foundImageUrlList = new ArrayList<>();
+		imageFileList.stream().forEach(
+				(imageFile) -> {
+					foundImageUrlList.add(imageFile.getDownloadUrl());
+				}
+		);
+
+		imageUrls = foundImageUrlList;
+
+
+		/*if (!optionalStrings.isEmpty()) {
 			imageUrls = optionalStrings.get();
-		}
+		}*/
 
 		return RecordDetailResponseDto.builder()
 				.recordId(record.getId())

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,6 +1,6 @@
 package com.recordit.server.service;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,7 +74,7 @@ public class RecordService {
 		);
 
 		Long recordId = recordRepository.save(record).getId();
-		log.info("저장한 레코드 ID : ", record);
+		log.info("저장한 레코드 ID : ", recordId);
 
 		if (files != null) {
 			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, recordId, files);
@@ -91,20 +91,20 @@ public class RecordService {
 		Record record = recordRepository.findById(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 
-		List<String> imageUrls = List.of();
+		List<String> imageUrls = Collections.emptyList();
 
 		Optional<List<ImageFile>> optionalImageFileList = imageFileRepository.findByRefIdAndRefType(recordId,
 				RefType.RECORD);
 
 		if (!optionalImageFileList.isEmpty()) {
-			List<String> foundImageUrlList = new ArrayList<>();
+
 			optionalImageFileList.get().stream()
 					.forEach(
 							(imageFile) -> {
-								foundImageUrlList.add(imageFile.getDownloadUrl());
+								imageUrls.add(imageFile.getDownloadUrl());
 							}
 					);
-			imageUrls = foundImageUrlList;
+
 		}
 
 		return RecordDetailResponseDto.builder()


### PR DESCRIPTION
## 관련 이슈 번호
[BE-121/ 레코드 작성,조회 기능 쿼리메소드 및  서비스 로직 수정](https://recodeit.atlassian.net/browse/BE-121)
<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->

## 설명
- 코드리뷰 내용을 참고하여 레코드 작성,조회 서비스 로직과 기존의 jpql을 쿼리메소드로 변경하였음
- 레코드 작성 서비스 메소드(writeRecord)에서 log.info("저장한 레코드 ID : ", record);  -> log.info("저장한 레코드 ID : ", recordId); 로 수정
- 레코드 상세조회 서비스 메소드(getDetailRecord)에서 List<String> imageUrls = List.of(); -> List<String> imageUrls = Collections.emptyList(); 로 변경하였음
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
