### PR TITLE
[BE-124] 로그인 판별 API

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -119,8 +119,8 @@ public class MemberController {
 		return ResponseEntity.status(HttpStatus.OK).body(false);
 	}
 
-	@GetMapping("/logincheck")
-	public ResponseEntity loginCheck() {
+	@GetMapping("/login")
+	public ResponseEntity checkLogin() {
 		sessionUtil.isCorrectSession();
 		log.info("정상적으로 로그인 되어있습니다.");
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -20,6 +20,7 @@ import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
 import com.recordit.server.service.MemberService;
+import com.recordit.server.util.SessionUtil;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -27,13 +28,16 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ResponseHeader;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
+@Slf4j
 public class MemberController {
 
 	private final MemberService memberService;
+	private final SessionUtil sessionUtil;
 
 	@ApiOperation(
 			value = "Oauth 로그인",
@@ -113,6 +117,13 @@ public class MemberController {
 			return ResponseEntity.status(HttpStatus.CONFLICT).body(true);
 		}
 		return ResponseEntity.status(HttpStatus.OK).body(false);
+	}
+
+	@GetMapping("/logincheck")
+	public ResponseEntity loginCheck() {
+		sessionUtil.isCorrectSession();
+		log.info("정상적으로 로그인 되어있습니다.");
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
@@ -50,5 +50,13 @@ public class MemberExceptionHandler {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
 	}
+
+	@ExceptionHandler(SessionAuthenticationException.class)
+	public ResponseEntity<ErrorMessage> handleSessionAuthenticationException(
+			SessionAuthenticationException exception) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
+				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
+	}
+
 }
 

--- a/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
@@ -55,7 +55,7 @@ public class MemberExceptionHandler {
 	public ResponseEntity<ErrorMessage> handleSessionAuthenticationException(
 			SessionAuthenticationException exception) {
 		return ResponseEntity.status(HttpStatus.FORBIDDEN)
-				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
+				.body(ErrorMessage.of(exception, HttpStatus.FORBIDDEN));
 	}
 
 }

--- a/src/main/java/com/recordit/server/exception/member/SessionAuthenticationException.java
+++ b/src/main/java/com/recordit/server/exception/member/SessionAuthenticationException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.member;
+
+public class SessionAuthenticationException extends RuntimeException {
+	public SessionAuthenticationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -25,8 +25,8 @@ public class SessionUtil {
 	public Long findUserIdBySession() {
 		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
-			invalidateSession();
 			log.info("세션에 사용자 정보가 저장되어 있지 않습니다");
+			invalidateSession();
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
 		return userId;

--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -26,7 +26,7 @@ public class SessionUtil {
 		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
 			invalidateSession();
-			log.info("세션에서 사용자 정보를 찾지 못함");
+			log.info("세션에 사용자 정보가 저장되어 있지 않습니다");
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
 		return userId;

--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -5,11 +5,14 @@ import javax.servlet.http.HttpSession;
 import org.springframework.stereotype.Component;
 
 import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
+import com.recordit.server.exception.member.SessionAuthenticationException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SessionUtil {
 
 	private static final String PREFIX_USER_ID = "LOGIN_USER_ID";
@@ -22,9 +25,19 @@ public class SessionUtil {
 	public Long findUserIdBySession() {
 		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
+			invalidateSession();
+			log.info("세션에서 사용자 정보를 찾지 못함");
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
 		return userId;
+	}
+
+	public void isCorrectSession() {
+		if (httpSession.getAttribute(PREFIX_USER_ID) == null) {
+			log.info("로그인이 되어있지 않아 접근이 거부되었습니다.");
+			invalidateSession();
+			throw new SessionAuthenticationException("로그인이 되어있지 않아 접근이 거부되었습니다.");
+		}
 	}
 
 	public void invalidateSession() {


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-124 / 로그인 판별 API](https://recodeit.atlassian.net/browse/BE-124)

## 설명
세션이 없는(로그인을 시도하지 않은) 사용자도 세션에 접근하는 순간 비어있는 세션이 생기기 때문에, invalidateSession 메서드를 실행하여 세션을 날려주어야 합니다.

## 변경사항
- [x] MemberController에 loginCheck 메서드 생성
- [x] SessionAuthenticationException 생성
- [x]  SessionUtil에 로그인되어있는지 확인하는 isCorrectSession메서드 생성
- [x] 세션이 없는 사용자도 세션에 접근하는 순간 빈 세션이 생기기 때문에, 로그인 되어있지 않는 사용자라면 invalidateSession 메서드를 실행하여 세션 초기화

## 질문사항