### PR TITLE
[BE-135] Session Serializer 타입 에러 수정

### DIFF
--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -23,13 +23,13 @@ public class SessionUtil {
 	}
 
 	public Long findUserIdBySession() {
-		Long userId = (Long)httpSession.getAttribute(PREFIX_USER_ID);
+		Integer userId = (Integer)httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
 			log.info("세션에 사용자 정보가 저장되어 있지 않습니다");
 			invalidateSession();
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
-		return userId;
+		return userId.longValue();
 	}
 
 	public void isCorrectSession() {


### PR DESCRIPTION
## 관련 이슈 번호

[BE-135 / Session Serializer 타입 에러 수정](https://recodeit.atlassian.net/browse/BE-135)

## 설명
- Session Serializer 변경으로 인해 기존에 Long으로 받아와지던 코드가 Integer로만 받아와져서 발생한 에러 수정

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
