### PR TITLE
[BE-137] swagger endpoint명에 /api 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,8 @@ springfox:
   documentation:
     swagger:
       use-model-v3: false
+    swagger-ui:
+      base-url: /api
 logging:
   config: classpath:log4j2-dev.xml
 cors:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,8 @@ springfox:
   documentation:
     swagger:
       use-model-v3: false
+    swagger-ui:
+      base-url: /api
 logging:
   config: classpath:log4j2-local.xml
 cors:


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-137 / swagger endpoint명에 /api 추가](https://recodeit.atlassian.net/browse/BE-137)

## 설명
nginx 설정으로 백엔드 모든 endpoint명에 /api가 추가됨에 따라 swagger endpoint 명에도 추가하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
