### PR TITLE
[BE-138] 레코드, 댓글에 이미지 파일 저장 개수 Column을 제거

### DIFF
--- a/src/main/java/com/recordit/server/domain/Comment.java
+++ b/src/main/java/com/recordit/server/domain/Comment.java
@@ -35,6 +35,4 @@ public class Comment extends BaseEntity {
 	@Column(name = "CONTENT")
 	private String content;
 
-	@Column(name = "NUM_OF_IMAGE")
-	private Integer numOfImage;
 }

--- a/src/main/java/com/recordit/server/domain/Record.java
+++ b/src/main/java/com/recordit/server/domain/Record.java
@@ -45,9 +45,6 @@ public class Record extends BaseEntity {
 	@Column(name = "CONTENT")
 	private String content;
 
-	@Column(name = "NUM_OF_IMAGE")
-	private Integer numOfImage;
-
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "RECORD_COLOR_ID")
 	private RecordColor recordColor;
@@ -61,7 +58,6 @@ public class Record extends BaseEntity {
 			Member writer,
 			String title,
 			String content,
-			Integer numOfImage,
 			RecordColor recordColor,
 			RecordIcon recordIcon
 	) {
@@ -69,7 +65,6 @@ public class Record extends BaseEntity {
 		this.writer = writer;
 		this.title = title;
 		this.content = content;
-		this.numOfImage = numOfImage;
 		this.recordColor = recordColor;
 		this.recordIcon = recordIcon;
 	}
@@ -78,7 +73,6 @@ public class Record extends BaseEntity {
 			WriteRecordRequestDto writeRecordRequestDto,
 			RecordCategory recordCategory,
 			Member member,
-			Integer numOfImage,
 			RecordColor recordColor,
 			RecordIcon recordIcon
 	) {
@@ -87,7 +81,6 @@ public class Record extends BaseEntity {
 				member,
 				writeRecordRequestDto.getTitle(),
 				writeRecordRequestDto.getContent(),
-				numOfImage,
 				recordColor,
 				recordIcon
 		);

--- a/src/test/java/com/recordit/server/util/SessionUtilTest.java
+++ b/src/test/java/com/recordit/server/util/SessionUtilTest.java
@@ -42,14 +42,14 @@ public class SessionUtilTest {
 		@DisplayName("세션에 userId가 있으면 값이 찾아와진다")
 		void 세션에_정상적으로_userId를_저장하고_있으면_정상적으로_값이_찾아와진다() {
 			// given
-			long userId = 1L;
+			Integer userId = 1; // Session Serializer 때문에 원래 Long을 넣어야 하지만 테스트에서 Integer를 사용
 			mockHttpSession.setAttribute("LOGIN_USER_ID", userId);
 
 			// when
 			Long userIdBySession = sessionUtil.findUserIdBySession();
 
 			// then
-			assertThat(userIdBySession.longValue()).isEqualTo(userId);
+			assertThat(userIdBySession.longValue()).isEqualTo(1L);
 			assertThatCode(() -> sessionUtil.findUserIdBySession()).doesNotThrowAnyException();
 		}
 


### PR DESCRIPTION
## 관련 이슈 번호

[BE-138 / 레코드, 댓글에 이미지 파일 저장 개수 Column을 제거](https://recodeit.atlassian.net/browse/BE-138)

## 설명
- Record, Comment에 이미지 개수 Column 삭제
- Session Serializer 변경 후 Test 코드 수정

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
