### PR TITLE
[BE-142] fix: SessionUtil findUserIdBySession 메서드에서 id값 Long으로 형변환

### DIFF
--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -23,7 +23,7 @@ public class SessionUtil {
 	}
 
 	public Long findUserIdBySession() {
-		Integer userId = (Integer)httpSession.getAttribute(PREFIX_USER_ID);
+		Long userId = Long.valueOf(httpSession.getAttribute(PREFIX_USER_ID).toString());
 		if (userId == null) {
 			log.info("세션에 사용자 정보가 저장되어 있지 않습니다");
 			invalidateSession();


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-142 / SessionUtil findUserIdBySession 메서드에서 id값 Long으로 형변환](https://recodeit.atlassian.net/browse/BE-142) 

## 설명
기존 springSessionDefaultRedisSerializer를 Jackson2JsonRedisSerializer 로 변경하면서 형변환 문제가 생겼습니다.
Long -> Integer로 변경 후 문제가 해결되었으나
다른 문제 발생으로 처음부터 Long으로 변환하였습니다.
## 변경사항
- [x] SessionUtil에 Long으로 형변환

## 질문사항
