### PR TITLE
[BE-141] ImageFileService에 저장 부분 리팩토링 및 URL 조회 기능 추가

### DIFF
--- a/src/main/java/com/recordit/server/constant/ImageFileExtension.java
+++ b/src/main/java/com/recordit/server/constant/ImageFileExtension.java
@@ -1,0 +1,7 @@
+package com.recordit.server.constant;
+
+public enum ImageFileExtension {
+	JPG, JPEG, jpg, jpeg,
+	PNG, png,
+	SVG, svg
+}

--- a/src/main/java/com/recordit/server/exception/file/FileExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/file/FileExceptionHandler.java
@@ -31,4 +31,12 @@ public class FileExceptionHandler {
 		return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
 				.body(ErrorMessage.of(exception, HttpStatus.UNPROCESSABLE_ENTITY));
 	}
+
+	@ExceptionHandler(FileExtensionNotAllowedException.class)
+	public ResponseEntity<ErrorMessage> handleFileExtensionNotAllowedException(
+			FileExtensionNotAllowedException exception
+	) {
+		return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+				.body(ErrorMessage.of(exception, HttpStatus.UNPROCESSABLE_ENTITY));
+	}
 }

--- a/src/main/java/com/recordit/server/exception/file/FileExtensionNotAllowedException.java
+++ b/src/main/java/com/recordit/server/exception/file/FileExtensionNotAllowedException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.file;
+
+public class FileExtensionNotAllowedException extends RuntimeException {
+	public FileExtensionNotAllowedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -1,8 +1,16 @@
 package com.recordit.server.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.recordit.server.constant.RefType;
 import com.recordit.server.domain.ImageFile;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+
+	Optional<ImageFile> findByRefTypeAndRefId(RefType refType, Long refId);
+
+	List<ImageFile> findAllByRefTypeAndRefId(RefType refType, Long refId);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -93,8 +93,12 @@ public class RecordService {
 
 		List<String> imageUrls = Collections.emptyList();
 
-		Optional<List<ImageFile>> optionalImageFileList = imageFileRepository.findByRefIdAndRefType(recordId,
-				RefType.RECORD);
+		Optional<List<ImageFile>> optionalImageFileList = Optional.of(
+				imageFileRepository.findAllByRefTypeAndRefId(
+						RefType.RECORD,
+						recordId
+				)
+		);
 
 		if (!optionalImageFileList.isEmpty()) {
 

--- a/src/test/java/com/recordit/server/service/ImageFileServiceTest.java
+++ b/src/test/java/com/recordit/server/service/ImageFileServiceTest.java
@@ -17,8 +17,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.constant.RefType;
-import com.recordit.server.exception.file.EmptyFileException;
 import com.recordit.server.exception.file.FileContentTypeNotAllowedException;
+import com.recordit.server.exception.file.FileExtensionNotAllowedException;
 import com.recordit.server.repository.ImageFileRepository;
 import com.recordit.server.util.S3Uploader;
 
@@ -47,15 +47,17 @@ class ImageFileServiceTest {
 		private final List<MultipartFile> mockMultipartFiles = List.of(mock);
 
 		@Test
-		@DisplayName("빈 파일이 넘어오면 예외를 던진다")
+		@DisplayName("빈 파일이 넘어오면 null을 응답한다")
 		void 빈_파일이_넘어오면_예외를_던진다() {
 			// given
 			given(mock.isEmpty())
 					.willReturn(true);
 
-			// when, then
-			assertThatThrownBy(() -> imageFileService.saveAttachmentFiles(refType, refId, mockMultipartFiles))
-					.isInstanceOf(EmptyFileException.class);
+			// when
+			List<String> result = imageFileService.saveAttachmentFiles(refType, refId, mockMultipartFiles);
+
+			// then
+			assertThat(result.isEmpty()).isTrue();
 		}
 
 		@Test
@@ -70,6 +72,22 @@ class ImageFileServiceTest {
 			// when, then
 			assertThatThrownBy(() -> imageFileService.saveAttachmentFiles(refType, refId, mockMultipartFiles))
 					.isInstanceOf(FileContentTypeNotAllowedException.class);
+		}
+
+		@Test
+		@DisplayName("규정한 이미지 파일 확장자가 아니면 예외를 던진다")
+		void 규정한_이미지_파일_확장자가_아니면_예외를_던진다() {
+			// given
+			given(mock.isEmpty())
+					.willReturn(false);
+			given(mock.getContentType())
+					.willReturn("image/jpg");
+			given(mock.getOriginalFilename())
+					.willReturn("test.xlsx");
+
+			// when, then
+			assertThatThrownBy(() -> imageFileService.saveAttachmentFiles(refType, refId, mockMultipartFiles))
+					.isInstanceOf(FileExtensionNotAllowedException.class);
 		}
 
 		@Test


### PR DESCRIPTION
## 관련 이슈 번호

[BE-141 / ImageFileService에 저장 부분 리팩토링 및 URL 조회 기능 추가](https://recodeit.atlassian.net/browse/BE-141)

## 설명
- 이미지 저장 로직에 파일 확장자 검증 기능 추가
- 저장된 이미지 URL 조회 기능 추가

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
