### PR TITLE
[BE-143] SessionUtil findUserIdBySession 메서드 NullPointException 버그 fix

### DIFF
--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -23,13 +23,13 @@ public class SessionUtil {
 	}
 
 	public Long findUserIdBySession() {
-		Long userId = Long.valueOf(httpSession.getAttribute(PREFIX_USER_ID).toString());
+		Object userId = httpSession.getAttribute(PREFIX_USER_ID);
 		if (userId == null) {
 			log.info("세션에 사용자 정보가 저장되어 있지 않습니다");
 			invalidateSession();
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
-		return userId.longValue();
+		return Long.valueOf(userId.toString());
 	}
 
 	public void isCorrectSession() {


### PR DESCRIPTION

## 관련 이슈 번호
- [BE-143 / SessionUtil findUserIdBySession 메서드 NullPointException 버그 fix](https://recodeit.atlassian.net/browse/BE-143)

## 설명
SessionUtilTest에서 `세션에서_userId를_찾을_때 세션에_userId가_없으면_예외를_던진다` 테스트가 실패하였습니다.

기존 `Long userId = Long.valueOf(httpSession.getAttribute(PREFIX_USER_ID).toString());` 이라면
null일 때 toString()이 불가능하여 수정하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
