### PR TITLE
[BE-113] 로그 파일 외부로 전송 및 관리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Custom ###
 logs/
+*.pem

--- a/build.gradle
+++ b/build.gradle
@@ -60,3 +60,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,4 @@
+FROM adoptopenjdk/openjdk11
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-113 / 로그 파일 외부로 전송 및 관리](https://recodeit.atlassian.net/browse/BE-113)

## 설명
기존 cloudtype에 배포된 dev서버가 재 배포 시점에 dockerfile로 빌드가 되어
로그를 확인할 수 없는 문제가 있었습니다.

유저테스트를 위해 prod 환경을 구성하여야 하여
로그 수집을 위해 aws ec2에 배포 하기 위한 설정을 진행하였습니다.

## 변경사항
- [x] dockerfile 작성
- [x] gitignore에 .pem 파일 안올라가도록 변경
- [x] build시 plain jar 생기지 않도록 build.gradle 변경 


## 질문사항
