### PR TITLE
[BE-154] 로그인 판별 API endpoint명을 /auth로 변경하고 회원의 닉네임 반환하도록 수정

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -119,11 +119,9 @@ public class MemberController {
 		return ResponseEntity.status(HttpStatus.OK).body(false);
 	}
 
-	@GetMapping("/login")
-	public ResponseEntity checkLogin() {
-		sessionUtil.isCorrectSession();
-		log.info("정상적으로 로그인 되어있습니다.");
-		return ResponseEntity.ok().build();
+	@GetMapping("/auth")
+	public ResponseEntity<String> findNicknameIfPresent() {
+		return ResponseEntity.status(HttpStatus.OK).body(memberService.findNicknameIfPresent());
 	}
 
 }

--- a/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/member/MemberExceptionHandler.java
@@ -50,13 +50,5 @@ public class MemberExceptionHandler {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
 	}
-
-	@ExceptionHandler(SessionAuthenticationException.class)
-	public ResponseEntity<ErrorMessage> handleSessionAuthenticationException(
-			SessionAuthenticationException exception) {
-		return ResponseEntity.status(HttpStatus.FORBIDDEN)
-				.body(ErrorMessage.of(exception, HttpStatus.FORBIDDEN));
-	}
-
 }
 

--- a/src/main/java/com/recordit/server/exception/member/SessionAuthenticationException.java
+++ b/src/main/java/com/recordit/server/exception/member/SessionAuthenticationException.java
@@ -1,7 +1,0 @@
-package com.recordit.server.exception.member;
-
-public class SessionAuthenticationException extends RuntimeException {
-	public SessionAuthenticationException(String message) {
-		super(message);
-	}
-}

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -15,6 +15,7 @@ import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
+import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.member.NotFoundRegisterSessionException;
 import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthService;
@@ -88,5 +89,12 @@ public class MemberService {
 			log.warn("중복된 닉네임이 존재함 : {}", nickname);
 			throw new DuplicateNicknameException("중복된 닉네임이 존재합니다.");
 		}
+	}
+
+	public String findNicknameIfPresent() {
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+		return member.getNickname();
 	}
 }

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -91,6 +91,7 @@ public class MemberService {
 		}
 	}
 
+	@Transactional(readOnly = true)
 	public String findNicknameIfPresent() {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		Member member = memberRepository.findById(userIdBySession)

--- a/src/main/java/com/recordit/server/util/SessionUtil.java
+++ b/src/main/java/com/recordit/server/util/SessionUtil.java
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpSession;
 import org.springframework.stereotype.Component;
 
 import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
-import com.recordit.server.exception.member.SessionAuthenticationException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,14 +29,6 @@ public class SessionUtil {
 			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
 		}
 		return Long.valueOf(userId.toString());
-	}
-
-	public void isCorrectSession() {
-		if (httpSession.getAttribute(PREFIX_USER_ID) == null) {
-			log.info("로그인이 되어있지 않아 접근이 거부되었습니다.");
-			invalidateSession();
-			throw new SessionAuthenticationException("로그인이 되어있지 않아 접근이 거부되었습니다.");
-		}
 	}
 
 	public void invalidateSession() {

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -24,7 +24,9 @@ import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
+import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.member.NotFoundRegisterSessionException;
+import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
 import com.recordit.server.repository.MemberRepository;
 import com.recordit.server.service.oauth.OauthService;
 import com.recordit.server.service.oauth.OauthServiceLocator;
@@ -211,6 +213,53 @@ public class MemberServiceTest {
 
 			// when, then
 			assertThatCode(() -> memberService.isDuplicateNickname(nickname))
+					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("로그인 된 사용자의 닉네임을 응답하는 기능에서")
+	class 로그인_된_사용자의_닉네임을_응답하는_기능에서 {
+
+		@Test
+		@DisplayName("로그인이 되어있지 않다면 예외를 던진다")
+		void 로그인이_되어있지_않으면_예외를_던진다() {
+			// given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(null);
+
+			// when, then
+			assertThatThrownBy(() -> memberService.findNicknameIfPresent())
+					.isInstanceOf(NotFoundUserInfoInSessionException.class);
+		}
+
+		@Test
+		@DisplayName("세션에 회원의 아이디는 존재하지만 테이블에 없다면 예외를 던진다")
+		void 세션에_회원의_아이디는_존재하지만_테이블에_없다면_예외를_던진다() {
+			// given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(1L);
+			given(memberRepository.findById(any()))
+					.willReturn(Optional.empty());
+
+			// when, then
+			assertThatThrownBy(() -> memberService.findNicknameIfPresent())
+					.isInstanceOf(MemberNotFoundException.class);
+		}
+
+		@Test
+		@DisplayName("정상적으로 로그인되어있고 테이블에도 정보가 있는 경우엔 예외를 던지지 않는다")
+		void 정상적으로_로그인되어있고_테이블에도_정보가_있는_경우엔_예외를_던지지_않는다() {
+			//given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(1L);
+			given(memberRepository.findById(any()))
+					.willReturn(Optional.of(mockMember));
+			given(mockMember.getNickname())
+					.willReturn(nickname);
+
+			// when, then
+			assertThatCode(() -> memberService.findNicknameIfPresent())
 					.doesNotThrowAnyException();
 		}
 	}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-154 / 로그인 판별 API endpoint명을 /auth로 변경하고 회원의 닉네임 반환하도록 수정](https://recodeit.atlassian.net/browse/BE-154)

## 설명
기존 로그인만 판별하던 API를 확장하여 닉네임을 return하도록 변경하였습니다.
endpoint명을 `GET /login`에서 `GET /auth`로 변경하였습니다.

## 변경사항
- [x] 테스트 코드 작성
- [x] sessionUtil에서 isCorrectSession 메서드 삭제
- [x] SessionAuthenticationException 삭제
- [x] ExceptionHandler에서 handleSessionAuthenticationException 제거 
- [x] `GET /login`에서 `GET /auth`로 변경
- [x] MemberService에서 findNicknameIfPresent 메서드 생성 

## 질문사항
자유롭게 의견 남겨주세요 🙇🏻
