### PR TITLE
[BE-156] 레코드 조회 시 이미지 리스트 객체를 이뮤터블에서 뮤터블로 변경

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,6 +1,6 @@
 package com.recordit.server.service;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,7 +91,7 @@ public class RecordService {
 		Record record = recordRepository.findById(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 
-		List<String> imageUrls = Collections.emptyList();
+		List<String> imageUrls = new ArrayList<>();
 
 		Optional<List<ImageFile>> optionalImageFileList = Optional.of(
 				imageFileRepository.findAllByRefTypeAndRefId(


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-156 / 레코드 조회 시 이미지 리스트 객체를 이뮤터블에서 뮤터블로 변경](https://recodeit.atlassian.net/browse/BE-156)

## 설명
기존 `imageUrls` List 객체가 이뮤터블 객체로 add 시점에 `java.lang.UnsupportedOperationException` 발생하여
뮤터블 객체로 변경하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
