### PR TITLE
[BE-154] 로그인된 회원 닉네임 반환 메서드 테스트코드 수정

### DIFF
--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -226,7 +226,7 @@ public class MemberServiceTest {
 		void 로그인이_되어있지_않으면_예외를_던진다() {
 			// given
 			given(sessionUtil.findUserIdBySession())
-					.willReturn(null);
+					.willThrow(new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다"));
 
 			// when, then
 			assertThatThrownBy(() -> memberService.findNicknameIfPresent())


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-154 / 로그인 판별 API endpoint명을 /auth로 변경하고 회원의 닉네임 반환하도록 수정](https://recodeit.atlassian.net/browse/BE-154)

## 설명
`로그인 된 사용자의 닉네임을 응답하는 기능에서` `로그인이 되어있지 않다면 예외를 던진다` 테스트코드 수정하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
