### PR TITLE
[BE-149] DTO 스네이크 케이스에서 카멜 케이스로 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/comment/CommentDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/CommentDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.comment;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,7 +10,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CommentDto {
 	private Long commentId;
 

--- a/src/main/java/com/recordit/server/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/CommentRequestDto.java
@@ -2,9 +2,6 @@ package com.recordit.server.dto.comment;
 
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -16,7 +13,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CommentRequestDto {
 	@ApiModelProperty(notes = "레코드의 id", required = true)
 	@NotNull

--- a/src/main/java/com/recordit/server/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/CommentResponseDto.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -18,7 +15,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CommentResponseDto {
 	@ApiModelProperty(notes = "레코드의 id", required = true)
 	@NotNull

--- a/src/main/java/com/recordit/server/dto/comment/WriteCommentRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/WriteCommentRequestDto.java
@@ -3,9 +3,6 @@ package com.recordit.server.dto.comment;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -18,7 +15,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WriteCommentRequestDto {
 
 	@ApiModelProperty(notes = "레코드의 id", required = true)

--- a/src/main/java/com/recordit/server/dto/comment/WriteCommentResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/WriteCommentResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.comment;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +11,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WriteCommentResponseDto {
 
 	private Long commentId;

--- a/src/main/java/com/recordit/server/dto/member/GoogleAccessTokenResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/GoogleAccessTokenResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.member;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +8,6 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleAccessTokenResponseDto {
 	private String accessToken;
 	private String expiresIn;

--- a/src/main/java/com/recordit/server/dto/member/GoogleUserInfoResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/GoogleUserInfoResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.member;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +8,6 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleUserInfoResponseDto {
 	private String iss;
 	private String azp;

--- a/src/main/java/com/recordit/server/dto/member/KakaoAccessTokenResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/KakaoAccessTokenResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.member;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +8,6 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoAccessTokenResponseDto {
 	private String accessToken;
 	private String tokenType;

--- a/src/main/java/com/recordit/server/dto/member/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/KakaoUserInfoResponseDto.java
@@ -1,8 +1,6 @@
 package com.recordit.server.dto.member;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +10,6 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoUserInfoResponseDto {
 	private String id;

--- a/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/LoginRequestDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.member;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -15,7 +12,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LoginRequestDto {
 
 	@ApiModelProperty(notes = "Oauth API에서 응답 받은 토큰", required = true)

--- a/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterRequestDto.java
@@ -2,9 +2,6 @@ package com.recordit.server.dto.member;
 
 import javax.validation.constraints.Pattern;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -17,7 +14,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RegisterRequestDto {
 
 	@ApiModelProperty(notes = "회원가입시 필요한 임시 Session", required = true)

--- a/src/main/java/com/recordit/server/dto/member/RegisterSessionResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/RegisterSessionResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.member;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -15,7 +12,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RegisterSessionResponseDto {
 
 	@ApiModelProperty(notes = "회원가입시 필요한 임시 Session", required = true)

--- a/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordDetailResponseDto.java
@@ -3,9 +3,6 @@ package com.recordit.server.dto.record;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +14,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecordDetailResponseDto {
 	private Long recordId;
 	private Long categoryId;

--- a/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
@@ -4,9 +4,6 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +15,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WriteRecordRequestDto {
 	@NotNull
 	private Long recordCategoryId;

--- a/src/main/java/com/recordit/server/dto/record/WriteRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordResponseDto.java
@@ -1,8 +1,5 @@
 package com.recordit.server.dto.record;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +11,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WriteRecordResponseDto {
 	private Long recordId;
 

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -3,8 +3,6 @@ package com.recordit.server.dto.record.category;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.recordit.server.domain.RecordCategory;
 
 import io.swagger.annotations.ApiModel;
@@ -19,7 +17,6 @@ import lombok.ToString;
 @ToString
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecordCategoryResponseDto {
 
 	@ApiModelProperty(notes = "레코드 카테고리 ID", required = true)


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-149 / DTO 스네이크 케이스에서 카멜 케이스로 변경](https://recodeit.atlassian.net/browse/BE-149)

## 설명
프론트엔드도 카멜케이스를 사용한다고 하여 모든 dto에 `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)` 제거

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
