### PR TITLE
[BE-157] fix: oauth dto 스네이크 케이스로 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/member/GoogleAccessTokenResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/GoogleAccessTokenResponseDto.java
@@ -1,5 +1,8 @@
 package com.recordit.server.dto.member;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleAccessTokenResponseDto {
 	private String accessToken;
 	private String expiresIn;

--- a/src/main/java/com/recordit/server/dto/member/GoogleUserInfoResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/GoogleUserInfoResponseDto.java
@@ -1,5 +1,8 @@
 package com.recordit.server.dto.member;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleUserInfoResponseDto {
 	private String iss;
 	private String azp;

--- a/src/main/java/com/recordit/server/dto/member/KakaoAccessTokenResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/KakaoAccessTokenResponseDto.java
@@ -1,5 +1,8 @@
 package com.recordit.server.dto.member;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoAccessTokenResponseDto {
 	private String accessToken;
 	private String tokenType;

--- a/src/main/java/com/recordit/server/dto/member/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/member/KakaoUserInfoResponseDto.java
@@ -1,6 +1,8 @@
 package com.recordit.server.dto.member;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,6 +12,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoUserInfoResponseDto {
 	private String id;


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-157 / oauth dto 스네이크 케이스로 변경](https://recodeit.atlassian.net/browse/BE-157)

## 설명
기존 스네이크 케이스에서 	카멜 케이스로 변경하였으나,
  oauth에서 응답하는 값은 스네이크 케이스로 응답되어
  oauth에서 응답되는 dto 는 스네이크 케이스로 변경하였습니다
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
