### PR TITLE
[BE-164] 첨부 파일 null로 받을 수 있도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
 	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<WriteCommentResponseDto> writeComment(
 			@ApiParam(required = true) @RequestPart(required = true) @Valid WriteCommentRequestDto writeCommentRequestDto,
-			@ApiParam @RequestPart MultipartFile attachment
+			@ApiParam @RequestPart(required = false) MultipartFile attachment
 	) {
 		return ResponseEntity.ok(commentService.writeComment(writeCommentRequestDto, attachment));
 	}

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -69,7 +69,9 @@ public class CommentService {
 				)
 		);
 
-		imageFileService.saveAttachmentFile(RefType.COMMENT, saveComment.getId(), attachment);
+		if (!imageFileService.isEmptyFile(attachment)) {
+			imageFileService.saveAttachmentFile(RefType.COMMENT, saveComment.getId(), attachment);
+		}
 
 		log.info("저장한 댓글 ID : {}", saveComment.getId());
 
@@ -120,7 +122,7 @@ public class CommentService {
 			WriteCommentRequestDto writeCommentRequestDto,
 			MultipartFile attachment
 	) {
-		if (attachment.isEmpty() && !StringUtils.hasText(writeCommentRequestDto.getComment())) {
+		if (imageFileService.isEmptyFile(attachment) && !StringUtils.hasText(writeCommentRequestDto.getComment())) {
 			throw new EmptyContentException("댓글 내용과 이미지 파일 모두 비어있을 수 없습니다.");
 		}
 	}

--- a/src/main/java/com/recordit/server/service/ImageFileService.java
+++ b/src/main/java/com/recordit/server/service/ImageFileService.java
@@ -130,4 +130,23 @@ public class ImageFileService {
 				.orElseThrow(() -> new FileExtensionNotAllowedException("지원하지 않은 파일 확장자입니다."));
 	}
 
+	public boolean isEmptyFile(MultipartFile multipartFile) {
+		if (multipartFile == null || multipartFile.isEmpty()) {
+			return true;
+		}
+		return false;
+	}
+
+	public boolean isEmptyFile(List<MultipartFile> multipartFiles) {
+		if (multipartFiles == null) {
+			return true;
+		}
+		for (MultipartFile multipartFile : multipartFiles) {
+			if (isEmptyFile(multipartFile)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -76,7 +76,7 @@ public class RecordService {
 		Long recordId = recordRepository.save(record).getId();
 		log.info("저장한 레코드 ID : ", recordId);
 
-		if (files != null) {
+		if (!imageFileService.isEmptyFile(files)) {
 			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, recordId, files);
 			log.info("저장된 이미지 urls : {}", urls);
 		}

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.domain.Comment;
 import com.recordit.server.domain.Record;
@@ -66,7 +67,7 @@ public class CommentServiceTest {
 					.build();
 			MockMultipartFile multipartFile = mock(MockMultipartFile.class);
 
-			given(multipartFile.isEmpty())
+			given(imageFileService.isEmptyFile(any(MultipartFile.class)))
 					.willReturn(true);
 
 			// when, then
@@ -85,8 +86,6 @@ public class CommentServiceTest {
 					.build();
 			MockMultipartFile multipartFile = mock(MockMultipartFile.class);
 
-			given(multipartFile.isEmpty())
-					.willReturn(false);
 			given(sessionUtil.findUserIdBySession())
 					.willReturn(1L);
 			given(memberRepository.findById(1L))
@@ -109,8 +108,6 @@ public class CommentServiceTest {
 					.build();
 			MockMultipartFile multipartFile = mock(MockMultipartFile.class);
 
-			given(multipartFile.isEmpty())
-					.willReturn(false);
 			given(sessionUtil.findUserIdBySession())
 					.willThrow(new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다"));
 			given(recordRepository.findById(writeCommentRequestDto.getRecordId()))
@@ -133,8 +130,6 @@ public class CommentServiceTest {
 			MockMultipartFile multipartFile = mock(MockMultipartFile.class);
 			Record record = mock(Record.class);
 
-			given(multipartFile.isEmpty())
-					.willReturn(false);
 			given(sessionUtil.findUserIdBySession())
 					.willThrow(new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다"));
 			given(recordRepository.findById(writeCommentRequestDto.getRecordId()))
@@ -257,7 +252,7 @@ public class CommentServiceTest {
 						.willReturn(Optional.of(parentComment));
 				given(parentComment.getParentComment())
 						.willReturn(grandParentComment);
-				
+
 				// when, then
 				assertThatThrownBy(() -> commentService.getCommentsBy(commentRequestDto))
 						.isInstanceOf(IllegalStateException.class);


### PR DESCRIPTION
## 관련 이슈 번호

[BE-164 / 첨부 파일 null로 받을 수 있도록 변경](https://recodeit.atlassian.net/browse/BE-164)

## 설명
- ImageFileSerivce에 파일이 비어있는지 검증하는 로직 추가
- RecordService 및 CommentService에 파일을 위에 언급한 비어 있는지 검증하는 로직을 통해 존재하면 저장하도록 변경
- CommentController에 이미지 파일을 필수가 아니도록 지정

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
