### PR TITLE
[BE-165] 댓글 조회시 Body가 아닌 Parameter로 받도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -5,8 +5,8 @@ import javax.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,7 +71,7 @@ public class CommentController {
 			)
 	})
 	@GetMapping
-	public ResponseEntity<CommentResponseDto> getComment(@Valid @RequestBody CommentRequestDto commentRequestDto) {
+	public ResponseEntity<CommentResponseDto> getComment(@Valid @ModelAttribute CommentRequestDto commentRequestDto) {
 		return ResponseEntity.ok(commentService.getCommentsBy(commentRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/CommentRequestDto.java
@@ -2,31 +2,29 @@ package com.recordit.server.dto.comment;
 
 import javax.validation.constraints.NotNull;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.ApiParam;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
-@ApiModel
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequestDto {
 
-	@ApiModelProperty(notes = "레코드 ID", required = true)
+	@ApiParam(value = "레코드 ID", required = true, example = "0")
 	@NotNull
 	private Long recordId;
 
-	@ApiModelProperty(notes = "자식 댓글을 조회하는 경우 부모 댓글의 ID")
+	@ApiParam(value = "자식 댓글을 조회하는 경우 부모 댓글의 ID", example = "0")
 	private Long parentId;
 
-	@ApiModelProperty(notes = "댓글 리스트의 요청 페이지 !주의: 0부터 시작", required = true)
+	@ApiParam(value = "댓글 리스트의 요청 페이지 !주의: 0부터 시작", required = true, example = "0")
 	@NotNull
-	private int page;
+	private Integer page;
 
-	@ApiModelProperty(notes = "댓글 리스트의 사이즈", required = true)
+	@ApiParam(value = "댓글 리스트의 사이즈", required = true, example = "10")
 	@NotNull
-	private int size;
+	private Integer size;
 }


### PR DESCRIPTION
## 관련 이슈 번호

[BE-165 / 댓글 조회시 Body가 아닌 Parameter로 받도록 변경](https://recodeit.atlassian.net/browse/BE-165)

## 설명
- CommentController에서 GET 요청인데 Body로 받는 부분을 ModelAttribute를 통해 Parameter로 받도록 변경
- 요청 DTO에 관련 설명 어노테이션들을 변경
- ModelAttribute를 사용하기 위해 기존의 NoArgs 어노테이션을 AllArgs로 변경

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
