### PR TITLE
[BE-167] validation 실패 시 ErrorMessage 변경

### DIFF
--- a/src/main/java/com/recordit/server/exception/ErrorMessage.java
+++ b/src/main/java/com/recordit/server/exception/ErrorMessage.java
@@ -15,14 +15,25 @@ public class ErrorMessage {
 	private String msg;
 	private LocalDateTime timestamp;
 
+	public ErrorMessage(Exception exception, HttpStatus httpStatus, String message) {
+		this.code = httpStatus.value();
+		this.errorSimpleName = exception.getClass().getSimpleName();
+		this.msg = message;
+		this.timestamp = LocalDateTime.now();
+	}
+
 	public ErrorMessage(Exception exception, HttpStatus httpStatus) {
 		this.code = httpStatus.value();
 		this.errorSimpleName = exception.getClass().getSimpleName();
-		this.msg = exception.getLocalizedMessage();
+		this.msg = exception.getMessage();
 		this.timestamp = LocalDateTime.now();
 	}
 
 	public static ErrorMessage of(Exception exception, HttpStatus httpStatus) {
 		return new ErrorMessage(exception, httpStatus);
+	}
+
+	public static ErrorMessage of(Exception exception, HttpStatus httpStatus, String message) {
+		return new ErrorMessage(exception, httpStatus, message);
 	}
 }

--- a/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
@@ -14,7 +14,9 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorMessage> handleMethodArgumentNotValidException(
 			MethodArgumentNotValidException exception) {
+		String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
 		return ResponseEntity.badRequest()
-				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST, message));
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-167 / validation 실패 시 ErrorMessage 변경](https://recodeit.atlassian.net/browse/BE-167) 

## 설명
validation 실패 시 발생하는 MethodArgumentNotValidException의 경우 기존 아래와 같이 나오던 값을
```json
{
    "code": 400,
    "errorSimpleName": "MethodArgumentNotValidException",
    "msg": "Validation failed for argument [0] in public org.springframework.http.ResponseEntity<com.recordit.server.dto.record.WriteRecordResponseDto> com.recordit.server.controller.RecordController.writeRecord(com.recordit.server.dto.record.WriteRecordRequestDto,java.util.List<org.springframework.web.multipart.MultipartFile>): [Field error in object 'writeRecordRequestDto' on field 'iconName': rejected value []; codes [NotBlank.writeRecordRequestDto.iconName,NotBlank.iconName,NotBlank.java.lang.String,NotBlank]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [writeRecordRequestDto.iconName,iconName]; arguments []; default message [iconName]]; default message [아이콘 이름은 빈 값일 수 없습니다.]] ",
    "timestamp": "2023-01-16T01:32:33.137705"
}
```
아래와 같이 변경되도록 수정하였습니다.

```json
{
    "code": 400,
    "errorSimpleName": "MethodArgumentNotValidException",
    "msg": "아이콘 이름은 빈 값일 수 없습니다.",
    "timestamp": "2023-01-16T01:32:06.412778"
}
```
## 변경사항

## 질문사항
