### PR TITLE
[BE-170] 정책 변경으로 인한 WriteRecordRequestDto title Size 12로 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
@@ -19,7 +19,7 @@ public class WriteRecordRequestDto {
 	@NotNull
 	private Long recordCategoryId;
 
-	@Size(max = 10, message = "레코드 제목은 최대 10자 입니다.")
+	@Size(max = 12, message = "레코드 제목은 최대 10자 입니다.")
 	@NotBlank(message = "레코드 제목은 빈 값일 수 없습니다.")
 	private String title;
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-170 / 정책 변경으로 인한 WriteRecordRequestDto title Size 12로 변경](https://recodeit.atlassian.net/browse/BE-170)

## 설명
정책 변경으로 인해서 Record 작성 시 Validation Title Size를 기존 10 -> 12로 변경 하였습니다.

## 변경사항

## 질문사항
