### PR TITLE
[BE-147] feat : 추억레코드 리스트 조회 기능 개발

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -11,14 +11,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.recordit.server.dto.record.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.ErrorMessage;
+import com.recordit.server.exception.record.InvalidPageParameterException;
 import com.recordit.server.service.RecordService;
 
 import io.swagger.annotations.ApiOperation;
@@ -75,4 +78,26 @@ public class RecordController {
 		return ResponseEntity.ok().body(recordService.getDetailRecord(recordId));
 	}
 
+	@ApiOperation(
+			value = "추억레코드 리스트를 내림차순으로 7개씩 조회",
+			notes = "추억레코드 리스트를 내림차순으로 7개씩 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "추억레코드 리스트 조회 성공",
+					response = RecordDetailResponseDto.class
+			),
+			@ApiResponse(
+					code = 400, message = "페이지 파라미터가 음수일 경우",
+					response = ErrorMessage.class
+			)
+	})
+	@GetMapping("memory-list")
+	public ResponseEntity<MemoryRecordResponseDto> getMemoryRecordList(
+			@RequestParam String pageNum) {
+		if (Integer.parseInt(pageNum) < 0) {
+			throw new InvalidPageParameterException("페이지 파라미터는 음수일 수 없습니다.");
+		}
+		return ResponseEntity.ok().body(recordService.getMemoryRecordList(Integer.parseInt(pageNum)));
+	}
 }

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -88,15 +88,15 @@ public class RecordController {
 					response = RecordDetailResponseDto.class
 			),
 			@ApiResponse(
-					code = 400, message = "페이지 파라미터가 음수일 경우",
+					code = 400, message = "페이지 파라미터가 음수, 실수, 숫자가 아닌경우 조회 실패",
 					response = ErrorMessage.class
 			)
 	})
 	@GetMapping("memory-list")
 	public ResponseEntity<MemoryRecordResponseDto> getMemoryRecordList(
 			@RequestParam String pageNum) {
-		if (Integer.parseInt(pageNum) < 0) {
-			throw new InvalidPageParameterException("페이지 파라미터는 음수일 수 없습니다.");
+		if (!pageNum.matches("\\d+")) {
+			throw new InvalidPageParameterException("페이지 파라미터는 음수, 실수, 숫자가 아닌 문자열일 수 없습니다.");
 		}
 		return ResponseEntity.ok().body(recordService.getMemoryRecordList(Integer.parseInt(pageNum)));
 	}

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -3,10 +3,13 @@ package com.recordit.server.controller;
 import java.util.List;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,8 +24,8 @@ import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.ErrorMessage;
-import com.recordit.server.exception.record.InvalidPageParameterException;
 import com.recordit.server.service.RecordService;
+import com.recordit.server.util.SessionUtil;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -32,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/record")
 public class RecordController {
 
@@ -95,10 +99,11 @@ public class RecordController {
 	})
 	@GetMapping("memory-list")
 	public ResponseEntity<MemoryRecordResponseDto> getMemoryRecordList(
-			@RequestParam String pageNum) {
-		if (!pageNum.matches("\\d+")) {
-			throw new InvalidPageParameterException("페이지 파라미터는 음수, 실수, 숫자가 아닌 문자열일 수 없습니다.");
-		}
+			@RequestParam(required = false)
+			@NotBlank(message = "페이지 파라미터는 빈값이거나 빈문자열일 수 없습니다.")
+			@Pattern(regexp = "\\d+", message = "페이지 파라미터는 음수, 실수, 숫자가 아닌 문자열일 수 없습니다.")
+			String pageNum
+	) {
 		return ResponseEntity.ok().body(recordService.getMemoryRecordList(Integer.parseInt(pageNum)));
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordCommentDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordCommentDto.java
@@ -1,0 +1,47 @@
+package com.recordit.server.dto.record;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.recordit.server.domain.Comment;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryRecordCommentDto {
+	@ApiModelProperty(notes = "추억레코드 댓글 아이디")
+	private Long commentId;
+
+	@ApiModelProperty(notes = "추억레코드 댓글 내용")
+	private String content;
+
+	@Builder
+	public MemoryRecordCommentDto(Long commentId, String content) {
+		this.commentId = commentId;
+		this.content = content;
+	}
+
+	public static List<MemoryRecordCommentDto> asMemoryRecordCommentDtoList(List<Comment> commentList) {
+		List<MemoryRecordCommentDto> memoryRecordCommentDtoList = new ArrayList<>();
+
+		for (Comment comment : commentList) {
+			memoryRecordCommentDtoList.add(
+					MemoryRecordCommentDto.builder()
+							.commentId(comment.getId())
+							.content(comment.getContent())
+							.build()
+			);
+		}
+
+		return memoryRecordCommentDtoList;
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordDto.java
@@ -1,0 +1,31 @@
+package com.recordit.server.dto.record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryRecordDto {
+	@ApiModelProperty(notes = "마이 레코드 아이디")
+	private Long recordId;
+
+	@ApiModelProperty(notes = "마이 레코드 제목")
+	private String title;
+
+	@ApiModelProperty(notes = "마이 레코드 아이콘 이름")
+	private String iconName;
+
+	@Builder
+	public MemoryRecordDto(Long recordId, String title, String iconName) {
+		this.recordId = recordId;
+		this.title = title;
+		this.iconName = iconName;
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordDto.java
@@ -1,5 +1,7 @@
 package com.recordit.server.dto.record;
 
+import java.util.List;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -13,19 +15,33 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemoryRecordDto {
-	@ApiModelProperty(notes = "마이 레코드 아이디")
+	@ApiModelProperty(notes = "추억 레코드 아이디")
 	private Long recordId;
 
-	@ApiModelProperty(notes = "마이 레코드 제목")
+	@ApiModelProperty(notes = "추억 레코드 제목")
 	private String title;
 
-	@ApiModelProperty(notes = "마이 레코드 아이콘 이름")
+	@ApiModelProperty(notes = "추억 레코드 아이콘 이름")
 	private String iconName;
 
+	@ApiModelProperty(notes = "추억 레코드 아이콘 색상")
+	private String iconColor;
+
+	@ApiModelProperty(notes = "추억 레코드 댓글 리스트 ")
+	private List<MemoryRecordCommentDto> commentList;
+
 	@Builder
-	public MemoryRecordDto(Long recordId, String title, String iconName) {
+	public MemoryRecordDto(
+			Long recordId,
+			String title,
+			String iconName,
+			String iconColor,
+			List<MemoryRecordCommentDto> commentList
+	) {
 		this.recordId = recordId;
 		this.title = title;
 		this.iconName = iconName;
+		this.iconColor = iconColor;
+		this.commentList = commentList;
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
@@ -1,0 +1,41 @@
+package com.recordit.server.dto.record;
+
+import java.util.List;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryRecordResponseDto {
+	@ApiModelProperty(notes = "다음 페이지가 있는지 여부")
+	private Boolean hasNextPage;
+
+	@ApiModelProperty(notes = "처음 페이지 인지 여부")
+	private Boolean isFirstPage;
+
+	@ApiModelProperty(notes = "마지막 페이지 인지 여부")
+	private Boolean isLastPage;
+	@ApiModelProperty(notes = "추억 레코드 리스트")
+	private List<MemoryRecordDto> memoryRecordList;
+
+	@Builder
+	public MemoryRecordResponseDto(
+			Boolean hasNextPage,
+			Boolean isFirstPage,
+			Boolean isLastPage,
+			List<MemoryRecordDto> myRecordList
+	) {
+		this.hasNextPage = hasNextPage;
+		this.isFirstPage = isFirstPage;
+		this.isLastPage = isLastPage;
+		this.memoryRecordList = myRecordList;
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
@@ -23,6 +23,7 @@ public class MemoryRecordResponseDto {
 
 	@ApiModelProperty(notes = "마지막 페이지 인지 여부")
 	private Boolean isLastPage;
+
 	@ApiModelProperty(notes = "추억 레코드 리스트")
 	private List<MemoryRecordDto> memoryRecordList;
 

--- a/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/MemoryRecordResponseDto.java
@@ -1,6 +1,12 @@
 package com.recordit.server.dto.record;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import com.recordit.server.domain.Comment;
+import com.recordit.server.domain.Record;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -29,14 +35,24 @@ public class MemoryRecordResponseDto {
 
 	@Builder
 	public MemoryRecordResponseDto(
-			Boolean hasNextPage,
-			Boolean isFirstPage,
-			Boolean isLastPage,
-			List<MemoryRecordDto> myRecordList
+			Slice<Record> memoryRecordSlice,
+			List<List<Comment>> commentList
 	) {
-		this.hasNextPage = hasNextPage;
-		this.isFirstPage = isFirstPage;
-		this.isLastPage = isLastPage;
-		this.memoryRecordList = myRecordList;
+		this.hasNextPage = memoryRecordSlice.hasNext();
+		this.isFirstPage = memoryRecordSlice.isFirst();
+		this.isLastPage = memoryRecordSlice.isLast();
+		this.memoryRecordList = new ArrayList<>();
+
+		for (int i = 0; i < memoryRecordSlice.getContent().size(); i++) {
+			memoryRecordList.add(
+					MemoryRecordDto.builder()
+							.recordId(memoryRecordSlice.getContent().get(i).getId())
+							.title(memoryRecordSlice.getContent().get(i).getTitle())
+							.iconColor(memoryRecordSlice.getContent().get(i).getRecordColor().getName())
+							.iconName(memoryRecordSlice.getContent().get(i).getRecordIcon().getName())
+							.commentList(MemoryRecordCommentDto.asMemoryRecordCommentDtoList(commentList.get(i)))
+							.build()
+			);
+		}
 	}
 }

--- a/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.recordit.server.exception;
 
+import javax.validation.ConstraintViolationException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -15,6 +17,15 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorMessage> handleMethodArgumentNotValidException(
 			MethodArgumentNotValidException exception) {
 		String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST, message));
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorMessage> handleConstraintViolationException(
+			ConstraintViolationException exception) {
+		String message = exception.getConstraintViolations().iterator().next().getMessage();
 
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST, message));

--- a/src/main/java/com/recordit/server/exception/record/InvalidPageParameterException.java
+++ b/src/main/java/com/recordit/server/exception/record/InvalidPageParameterException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record;
+
+public class InvalidPageParameterException extends RuntimeException {
+	public InvalidPageParameterException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
@@ -34,5 +34,11 @@ public class RecordExceptionHandler {
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
-}
 
+	@ExceptionHandler(InvalidPageParameterException.class)
+	public ResponseEntity<ErrorMessage> handleInvalidPageParameterException(
+			InvalidPageParameterException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+}

--- a/src/main/java/com/recordit/server/repository/CommentRepository.java
+++ b/src/main/java/com/recordit/server/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package com.recordit.server.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -21,4 +23,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Page<Comment> findAllByParentComment(@Param("parentComment") Comment parentComment, Pageable pageable);
 
 	Long countAllByParentComment(Comment parentComment);
+
+	List<Comment> findTop5ByRecordAndParentCommentIsNullOrderByCreatedAtDesc(Record record);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,7 +1,12 @@
 package com.recordit.server.repository;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.recordit.server.domain.Member;
 import com.recordit.server.domain.Record;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
@@ -9,4 +14,5 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	// 		+ " where r.id = :id")
 	// Optional<Record> findById(Long id);
 
+	Slice<Record> findByWriterAndCreatedAtBefore(Member writer, LocalDateTime dateTime, Pageable pageable);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -14,5 +14,9 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	// 		+ " where r.id = :id")
 	// Optional<Record> findById(Long id);
 
-	Slice<Record> findByWriterAndCreatedAtBefore(Member writer, LocalDateTime dateTime, Pageable pageable);
+	Slice<Record> findByWriterAndCreatedAtBefore(
+			Member writer,
+			LocalDateTime dateTime,
+			Pageable pageable
+	);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -139,20 +139,22 @@ public class RecordService {
 				Sort.by(Sort.Direction.DESC, "createdAt")
 		);
 
+		List<List<Comment>> commentList = new ArrayList<>();
+
 		Slice<Record> recordSlice = recordRepository.findByWriterAndCreatedAtBefore(
 				member,
 				LocalDateTime.of(LocalDate.now(), LocalTime.MIN),
 				pageRequest
+		).map(
+				record -> {
+					List<Comment> list = commentRepository
+							.findTop5ByRecordAndParentCommentIsNullOrderByCreatedAtDesc(record);
+
+					commentList.add(list);
+
+					return record;
+				}
 		);
-
-		List<List<Comment>> commentList = new ArrayList<>();
-
-		for (Record record : recordSlice) {
-			List<Comment> findCommentList = commentRepository
-					.findTop5ByRecordAndParentCommentIsNullOrderByCreatedAtDesc(record);
-
-			commentList.add(findCommentList);
-		}
 
 		return MemoryRecordResponseDto.builder()
 				.memoryRecordSlice(recordSlice)

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -134,6 +134,7 @@ public class RecordService {
 				.build();
 	}
 
+	@Transactional(readOnly = true)
 	public MemoryRecordResponseDto getMemoryRecordList(Integer pageNum) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -145,13 +144,6 @@ public class RecordService {
 				LocalDateTime.of(LocalDate.now(), LocalTime.MIN),
 				pageRequest
 		);
-
-		if (!recordSlice.hasContent()) {
-			return MemoryRecordResponseDto.builder()
-					.memoryRecordSlice(recordSlice)
-					.commentList(Collections.emptyList())
-					.build();
-		}
 
 		List<List<Comment>> commentList = new ArrayList<>();
 

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,9 +1,15 @@
 package com.recordit.server.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +21,8 @@ import com.recordit.server.domain.Record;
 import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.domain.RecordColor;
 import com.recordit.server.domain.RecordIcon;
+import com.recordit.server.dto.record.MemoryRecordDto;
+import com.recordit.server.dto.record.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
@@ -46,6 +54,7 @@ public class RecordService {
 	private final RecordIconRepository recordIconRepository;
 	private final RecordRepository recordRepository;
 	private final ImageFileService imageFileService;
+	private final Integer FIX_PAGE_SIZE = 7;
 
 	@Transactional
 	public WriteRecordResponseDto writeRecord(WriteRecordRequestDto writeRecordRequestDto, List<MultipartFile> files) {
@@ -122,6 +131,47 @@ public class RecordService {
 				.iconName(record.getRecordIcon().getName())
 				.createdAt(record.getCreatedAt())
 				.imageUrls(imageUrls)
+				.build();
+	}
+
+	public MemoryRecordResponseDto getMemoryRecordList(Integer pageNum) {
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
+
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+		PageRequest pageRequest = PageRequest.of(pageNum, FIX_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+		Slice<Record> recordSlice = recordRepository.findByWriterAndCreatedAtBefore(member, LocalDateTime.of(
+				LocalDate.now(), LocalTime.MIN), pageRequest);
+
+		List<MemoryRecordDto> memoryRecordDtoList = new ArrayList<>();
+
+		if (!recordSlice.hasContent()) {
+			return MemoryRecordResponseDto.builder()
+					.hasNextPage(recordSlice.hasNext())
+					.isFirstPage(recordSlice.isFirst())
+					.isLastPage(recordSlice.isLast())
+					.myRecordList(memoryRecordDtoList)
+					.build();
+		}
+
+		for (Record record : recordSlice) {
+			memoryRecordDtoList.add(
+					MemoryRecordDto.builder()
+							.title(record.getTitle())
+							.recordId(record.getId())
+							.iconName(record.getRecordIcon().getName())
+							.build()
+			);
+		}
+
+		return MemoryRecordResponseDto.builder()
+				.hasNextPage(recordSlice.hasNext())
+				.isFirstPage(recordSlice.isFirst())
+				.isLastPage(recordSlice.isLast())
+				.myRecordList(memoryRecordDtoList)
 				.build();
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-147/ 추억레코드 리스트 조회 기능 개발](https://recodeit.atlassian.net/browse/BE-147)
## 설명
추억레코드 리스트를 조회하는 기능을 개발하였습니다.
## 변경사항
- [x] MemoryRecordResponseDto에서 필드 사이에 개행을 추가하였습니다.
- [x] 페이지 파라미터가 음수, 실수 , 숫자가 아닌 문자열인지 확인하는 코드를 추가하였습니다.
- [x] RecordService의 getMemoryRecordList메소드에 @Transactional(readOnly = true) 코드를 추가하였습니다.
- [x] 코드리뷰 피드백 반영
- [x] 추억레코드 조회시 해당 레코드에 달린 댓글도 가져오도록 수정
- [x]  누락된 MemoryRecordCommentDto.java파일을 첨부하였습니다.
- [x]  recordSlice가 조회 결과를 가지고 있는지 확인하는 로직을 삭제하였습니다.
- [x] 코멘트를 가져오는 for-each문을 map으로 대체
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
