### PR TITLE
[BE-174] fix: 레코드 삭제와 마이레코드 병합 중 conflict 발생하여 수정

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -161,10 +161,16 @@ public class RecordService {
 				.memoryRecordSlice(recordSlice)
 				.commentList(commentList)
 				.build();
-    }
-    
-  @Transactional
-  public void deleteRecord(Long recordId) {
+	}
+
+	@Transactional
+	public void deleteRecord(Long recordId) {
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
+
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
 		Record record = recordRepository.findByIdFetchWriter(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-174 / 레코드 삭제와 마이레코드 병합 중 conflict 발생하여 수정](https://recodeit.atlassian.net/browse/BE-174)

## 설명
마이레코드 marge시 컨플릭 발생하여 수정하였는데, 레코드 삭제 일부분 누락되서 다시 올립니당 🥲

## 변경사항

## 질문사항
