### PR TITLE
[BE-175] fix: 추억레코드 Swagger 응답 객체 올바르게 변경

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -26,7 +26,6 @@ import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.exception.ErrorMessage;
 import com.recordit.server.service.RecordService;
-import com.recordit.server.util.SessionUtil;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -92,7 +91,7 @@ public class RecordController {
 	@ApiResponses({
 			@ApiResponse(
 					code = 200, message = "추억레코드 리스트 조회 성공",
-					response = RecordDetailResponseDto.class
+					response = MemoryRecordResponseDto.class
 			),
 			@ApiResponse(
 					code = 400, message = "페이지 파라미터가 음수, 실수, 숫자가 아닌경우 조회 실패",


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-175 / 추억레코드 Swagger 응답 객체 올바르게 변경](https://recodeit.atlassian.net/browse/BE-175)

## 설명
열정이 작업한 추억레코드 Swagger response에 다른 객체가 들어가있어 변경하였습니당

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
