### PR TITLE
[BE-178] fix: 레코드 작성 시 title validation message 수정

### DIFF
--- a/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WriteRecordRequestDto.java
@@ -19,7 +19,7 @@ public class WriteRecordRequestDto {
 	@NotNull
 	private Long recordCategoryId;
 
-	@Size(max = 12, message = "레코드 제목은 최대 10자 입니다.")
+	@Size(max = 12, message = "레코드 제목은 최대 12자 입니다.")
 	@NotBlank(message = "레코드 제목은 빈 값일 수 없습니다.")
 	private String title;
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-178 / 레코드 작성 시 title validation message 수정](https://recodeit.atlassian.net/browse/BE-178)

## 설명
레코드 작성 시 title validation message 10자로 입력되어있어 정책에 맞도록 12자로 수정했습니다.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항