### PR TITLE
[BE-111] 레코드 카테고리 저장

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -2,12 +2,16 @@ package com.recordit.server.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
+import com.recordit.server.dto.record.category.SaveRecordCategoryRequestDto;
 import com.recordit.server.service.RecordCategoryService;
 
 import io.swagger.annotations.ApiOperation;
@@ -37,4 +41,11 @@ public class RecordCategoryController {
 		return ResponseEntity.ok(recordCategoryService.getAllRecordCategories());
 	}
 
+	@PostMapping
+	public ResponseEntity saveRecordCategories(
+			@RequestBody SaveRecordCategoryRequestDto saveRecordCategoryRequestDto
+	) {
+		recordCategoryService.saveRecordCategory(saveRecordCategoryRequestDto);
+		return new ResponseEntity(HttpStatus.CREATED);
+	}
 }

--- a/src/main/java/com/recordit/server/dto/record/category/SaveRecordCategoryRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/SaveRecordCategoryRequestDto.java
@@ -1,0 +1,30 @@
+package com.recordit.server.dto.record.category;
+
+import javax.validation.constraints.NotBlank;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SaveRecordCategoryRequestDto {
+	@ApiModelProperty(notes = "부모 카테고리 ID", required = true)
+	private Long parentCategoryId;
+
+	@ApiModelProperty(notes = "카테고리 이름", required = true)
+	@NotBlank(message = "카테고리 이름은 빈 값일 수 없습니다.")
+	private String name;
+
+	@Builder
+	public SaveRecordCategoryRequestDto(Long parentCategoryId, String name) {
+		this.parentCategoryId = parentCategoryId;
+		this.name = name;
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.recordit.server.controller.RecordController;
 import com.recordit.server.exception.ErrorMessage;
 import com.recordit.server.exception.member.MemberNotFoundException;
+import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,6 +25,13 @@ public class RecordExceptionHandler {
 	@ExceptionHandler(RecordColorNotFoundException.class)
 	public ResponseEntity<ErrorMessage> handleRecordColorNotFoundException(
 			RecordColorNotFoundException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+
+	@ExceptionHandler(RecordCategoryNotFoundException.class)
+	public ResponseEntity<ErrorMessage> handleRecordCategoryNotFoundException(
+			RecordCategoryNotFoundException exception) {
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}

--- a/src/main/java/com/recordit/server/exception/record/category/HaveParentRecordCategoryException.java
+++ b/src/main/java/com/recordit/server/exception/record/category/HaveParentRecordCategoryException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record.category;
+
+public class HaveParentRecordCategoryException extends RuntimeException {
+	public HaveParentRecordCategoryException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/category/RecordCategoryExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/category/RecordCategoryExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.recordit.server.exception.record.category;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.recordit.server.controller.RecordCategoryController;
+import com.recordit.server.exception.ErrorMessage;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice(basePackageClasses = RecordCategoryController.class)
+public class RecordCategoryExceptionHandler {
+	@ExceptionHandler(RecordCategoryNotFoundException.class)
+	public ResponseEntity<ErrorMessage> handleRecordCategoryNotFoundException(
+			RecordCategoryNotFoundException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+
+	@ExceptionHandler(HaveParentRecordCategoryException.class)
+	public ResponseEntity<ErrorMessage> handleHaveParentRecordCategoryException(
+			HaveParentRecordCategoryException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+}

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -6,12 +6,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
+import com.recordit.server.dto.record.category.SaveRecordCategoryRequestDto;
+import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
 import com.recordit.server.repository.RecordCategoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -60,5 +63,18 @@ public class RecordCategoryService {
 		}
 
 		return result;
+	}
+
+	@CacheEvict(value = "Categories", allEntries = true)
+	public void saveRecordCategory(SaveRecordCategoryRequestDto saveRecordCategoryRequestDto) {
+		RecordCategory parentRecordCategory = null;
+
+		if (saveRecordCategoryRequestDto.getParentCategoryId() != null) {
+			parentRecordCategory = recordCategoryRepository.findById(saveRecordCategoryRequestDto.getParentCategoryId())
+					.orElseThrow(() -> new RecordCategoryNotFoundException("지정한 부모 카테고리 정보를 찾을 수 없습니다."));
+		}
+
+		RecordCategory recordCategory = RecordCategory.of(parentRecordCategory, saveRecordCategoryRequestDto.getName());
+		recordCategoryRepository.save(recordCategory);
 	}
 }

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
 import com.recordit.server.dto.record.category.SaveRecordCategoryRequestDto;
+import com.recordit.server.exception.record.category.HaveParentRecordCategoryException;
 import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
 import com.recordit.server.repository.RecordCategoryRepository;
 
@@ -72,6 +73,10 @@ public class RecordCategoryService {
 		if (saveRecordCategoryRequestDto.getParentCategoryId() != null) {
 			parentRecordCategory = recordCategoryRepository.findById(saveRecordCategoryRequestDto.getParentCategoryId())
 					.orElseThrow(() -> new RecordCategoryNotFoundException("지정한 부모 카테고리 정보를 찾을 수 없습니다."));
+		}
+
+		if (parentRecordCategory != null && parentRecordCategory.getParentRecordCategory() != null) {
+			throw new HaveParentRecordCategoryException("부모 카테고리는 부모 카테고리를 가질 수 없습니다.");
 		}
 
 		RecordCategory recordCategory = RecordCategory.of(parentRecordCategory, saveRecordCategoryRequestDto.getName());

--- a/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
@@ -4,16 +4,21 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
+import com.recordit.server.dto.record.category.SaveRecordCategoryRequestDto;
+import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
 import com.recordit.server.repository.RecordCategoryRepository;
 
 @ExtendWith({MockitoExtension.class})
@@ -62,4 +67,47 @@ class RecordCategoryServiceTest {
 		assertThat(result.get(1).getId()).isEqualTo(3L);
 	}
 
+	@Nested
+	@DisplayName("레코드 카테고리를 저장_할 때")
+	class 레코드_카테고리를_저장_할_때 {
+
+		@Test
+		@DisplayName("부모 카테고리를 찾을 수 없는 경우 예외를 던진다")
+		void 부모_카테고리를_찾을_수_없는_경우_예외를_던진다() {
+			// given
+			SaveRecordCategoryRequestDto saveRecordCategoryRequestDto = SaveRecordCategoryRequestDto.builder()
+					.parentCategoryId(2L)
+					.name("슬퍼요")
+					.build();
+
+			given(recordCategoryRepository.findById(anyLong()))
+					.willReturn(Optional.empty());
+
+			// when, then
+			assertThatThrownBy(() -> recordCategoryService.saveRecordCategory(saveRecordCategoryRequestDto))
+					.isInstanceOf(RecordCategoryNotFoundException.class)
+					.hasMessage("지정한 부모 카테고리 정보를 찾을 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("정상적이라면 예외를 던지지 않는다")
+		void 정상적이라면_예외를_던지지_않는다() {
+			// given
+			RecordCategory recordCategory1 = mock(RecordCategory.class);
+			SaveRecordCategoryRequestDto saveRecordCategoryRequestDto = SaveRecordCategoryRequestDto.builder()
+					.parentCategoryId(2L)
+					.name("슬퍼요")
+					.build();
+
+			given(recordCategoryRepository.findById(anyLong()))
+					.willReturn(Optional.of(recordCategory1));
+
+			ArgumentCaptor<RecordCategory> captor = ArgumentCaptor.forClass(RecordCategory.class);
+
+			// when, then
+			assertThatCode(() -> recordCategoryService.saveRecordCategory(saveRecordCategoryRequestDto))
+					.doesNotThrowAnyException();
+			verify(recordCategoryRepository, times(1)).save(captor.capture());
+		}
+	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-111 / 레코드 카테고리 저장](https://recodeit.atlassian.net/browse/BE-111)

## 설명
레코드 카테고리 저장 API 생성

기존 레코드 카테고리 조회 시 redis에 캐시된 데이터 삭제를 위해
`@CacheEvict(value = "Categories", allEntries = true)` 어노테이션 사용

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
