### PR TITLE
[BE-180] 레코드 수정 시 title 수정 불가능 정책에 따라 변경

### DIFF
--- a/src/main/java/com/recordit/server/domain/Record.java
+++ b/src/main/java/com/recordit/server/domain/Record.java
@@ -92,7 +92,6 @@ public class Record extends BaseEntity {
 			final RecordColor recordColor,
 			final RecordIcon recordIcon
 	) {
-		this.title = modifyRecordRequestDto.getTitle();
 		this.content = modifyRecordRequestDto.getContent();
 		this.recordColor = recordColor;
 		this.recordIcon = recordIcon;

--- a/src/main/java/com/recordit/server/dto/record/ModifyRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ModifyRecordRequestDto.java
@@ -17,9 +17,6 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ModifyRecordRequestDto {
-	@Size(max = 12, message = "레코드 제목은 최대 12자 입니다.")
-	@NotBlank(message = "레코드 제목은 빈 값일 수 없습니다.")
-	private String title;
 
 	@Size(max = 200, message = "레코드 내용은 최대 200자 입니다.")
 	@NotBlank(message = "레코드 내용은 빈 값일 수 없습니다.")
@@ -35,13 +32,11 @@ public class ModifyRecordRequestDto {
 
 	@Builder
 	public ModifyRecordRequestDto(
-			String title,
 			String content,
 			String colorName,
 			String iconName,
 			List<String> deleteImages
 	) {
-		this.title = title;
 		this.content = content;
 		this.colorName = colorName;
 		this.iconName = iconName;

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -362,7 +362,6 @@ class RecordServiceTest {
 		private final MultipartFile mock = mock(MultipartFile.class);
 		private final List<MultipartFile> mockMultipartFiles = List.of(mock);
 
-		private final String title = "수정 된 제목";
 		private final String content = "수정 된 내용";
 		private final String colorName = "icon-purple";
 		private final String iconName = "moon";
@@ -370,7 +369,6 @@ class RecordServiceTest {
 		private List<String> deleteImages = List.of();
 
 		private final ModifyRecordRequestDto modifyRecordRequestDto = ModifyRecordRequestDto.builder()
-				.title(title)
 				.content(content)
 				.colorName(colorName)
 				.iconName(iconName)


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-180 / 레코드 수정 시 title 수정 불가능 정책에 따라 변경](https://recodeit.atlassian.net/browse/BE-180)

## 설명
레코드 수정 시 이틀 수정 불가능 정책이 정해져
그에 맞게 타이틀을 변경하지 않도록 코드 수정 하였습니다.

## 변경사항

## 질문사항
