### PR TITLE
[BE-181] 댓글 삭제 시 익명 댓글을 레코드 작성자가 삭제 가능하도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.dto.comment.CommentRequestDto;
 import com.recordit.server.dto.comment.CommentResponseDto;
+import com.recordit.server.dto.comment.DeleteCommentRequestDto;
 import com.recordit.server.dto.comment.ModifyCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentResponseDto;
@@ -97,9 +99,10 @@ public class CommentController {
 	})
 	@DeleteMapping("/{commentId}")
 	public ResponseEntity deleteComment(
-			@PathVariable("commentId") Long commentId
+			@PathVariable("commentId") Long commentId,
+			@RequestBody DeleteCommentRequestDto deleteCommentRequestDto
 	) {
-		commentService.deleteComment(commentId);
+		commentService.deleteComment(commentId, deleteCommentRequestDto);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/recordit/server/dto/comment/DeleteCommentRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/DeleteCommentRequestDto.java
@@ -1,0 +1,23 @@
+package com.recordit.server.dto.comment;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteCommentRequestDto {
+	@ApiModelProperty(notes = "레코드의 id", required = true)
+	private Long recordId;
+
+	@Builder
+	public DeleteCommentRequestDto(Long recordId) {
+		this.recordId = recordId;
+	}
+}

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -17,6 +17,7 @@ import com.recordit.server.domain.Member;
 import com.recordit.server.domain.Record;
 import com.recordit.server.dto.comment.CommentRequestDto;
 import com.recordit.server.dto.comment.CommentResponseDto;
+import com.recordit.server.dto.comment.DeleteCommentRequestDto;
 import com.recordit.server.dto.comment.ModifyCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentResponseDto;
@@ -121,7 +122,7 @@ public class CommentService {
 	}
 
 	@Transactional
-	public void deleteComment(Long commentId) {
+	public void deleteComment(Long commentId, DeleteCommentRequestDto deleteCommentRequestDto) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 
@@ -131,11 +132,22 @@ public class CommentService {
 		Comment findComment = commentRepository.findById(commentId)
 				.orElseThrow(() -> new CommentNotFoundException("댓글 정보를 가져올 수 없습니다."));
 
-		if (findComment.getWriter().getId() != member.getId()) {
-			throw new NotMatchCommentWriterException("로그인한 사용자와 댓글 작성자가 일치하지 않습니다.");
-		}
-
+		validateDeleteCommentMatchMember(deleteCommentRequestDto.getRecordId(), member, findComment);
 		commentRepository.delete(findComment);
+	}
+
+	private void validateDeleteCommentMatchMember(
+			Long recordId,
+			Member member,
+			Comment comment
+	) {
+		if (comment.getWriter() == null || comment.getWriter().getId() != member.getId()) {
+			Record record = recordRepository.findByIdFetchWriter(recordId)
+					.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
+			if (record.getWriter().getId() != member.getId()) {
+				throw new NotMatchCommentWriterException("로그인한 사용자가 댓글 작성자 또는 레코드 작성자가 아닙니다.");
+			}
+		}
 	}
 
 	private void validateEmptyContent(


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-181 / 댓글 삭제 시 익명 댓글을 레코드 작성자가 삭제 가능하도록 변경](https://recodeit.atlassian.net/browse/BE-181)

## 설명
기존 댓글 삭제 시 댓글의 작성자가 없는 비회원 댓글이 존재하여
`findComment.getWriter()` 에서 `nullPointException`이 발생 할 가능성이 있고,
비회원 댓글일 경우 레코드 작성자에 의해 삭제가 가능하여
그에맞도록 테스트코드 및 로직을 변경하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
