### PR TITLE
[BE-185] 비회원 댓글은 수정 불가능 하도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/exception/comment/CommentExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/comment/CommentExceptionHandler.java
@@ -51,4 +51,12 @@ public class CommentExceptionHandler {
 		return ResponseEntity.status(HttpStatus.FORBIDDEN)
 				.body(ErrorMessage.of(exception, HttpStatus.FORBIDDEN));
 	}
+
+	@ExceptionHandler(NotAllowedModifyWhenNonMemberException.class)
+	public ResponseEntity<ErrorMessage> handleNotAllowedModifyWhenNonMemberException(
+			NotAllowedModifyWhenNonMemberException exception) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
+				.body(ErrorMessage.of(exception, HttpStatus.FORBIDDEN));
+	}
+
 }

--- a/src/main/java/com/recordit/server/exception/comment/NotAllowedModifyWhenNonMemberException.java
+++ b/src/main/java/com/recordit/server/exception/comment/NotAllowedModifyWhenNonMemberException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.comment;
+
+public class NotAllowedModifyWhenNonMemberException extends RuntimeException {
+	public NotAllowedModifyWhenNonMemberException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -23,6 +23,7 @@ import com.recordit.server.dto.comment.WriteCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentResponseDto;
 import com.recordit.server.exception.comment.CommentNotFoundException;
 import com.recordit.server.exception.comment.EmptyContentException;
+import com.recordit.server.exception.comment.NotAllowedModifyWhenNonMemberException;
 import com.recordit.server.exception.comment.NotMatchCommentWriterException;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
@@ -189,6 +190,10 @@ public class CommentService {
 
 		Comment comment = commentRepository.findById(commentId)
 				.orElseThrow(() -> new CommentNotFoundException("댓글 정보를 가져올 수 없습니다."));
+
+		if (comment.getWriter() == null) {
+			throw new NotAllowedModifyWhenNonMemberException("비회원 댓글은 수정 불가능합니다.");
+		}
 
 		if (comment.getWriter().getId() != member.getId()) {
 			throw new NotMatchCommentWriterException("로그인한 사용자와 댓글 작성자가 일치하지 않습니다.");

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -27,6 +27,7 @@ import com.recordit.server.dto.comment.WriteCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentResponseDto;
 import com.recordit.server.exception.comment.CommentNotFoundException;
 import com.recordit.server.exception.comment.EmptyContentException;
+import com.recordit.server.exception.comment.NotAllowedModifyWhenNonMemberException;
 import com.recordit.server.exception.comment.NotMatchCommentWriterException;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.member.NotFoundUserInfoInSessionException;
@@ -455,6 +456,23 @@ public class CommentServiceTest {
 			assertThatThrownBy(() -> commentService.modifyComment(124L, modifyCommentRequestDto, files))
 					.isInstanceOf(CommentNotFoundException.class)
 					.hasMessage("댓글 정보를 가져올 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("비회원 댓글이라면 예외를 던진다")
+		void 비회원_댓글이라면_예외를_던진다() {
+			// given
+			given(memberRepository.findById(any()))
+					.willReturn(Optional.of(mockMember));
+			given(commentRepository.findById(any()))
+					.willReturn(Optional.of(mockComment));
+			given(mockComment.getWriter())
+					.willReturn(null);
+
+			// when, then
+			assertThatThrownBy(() -> commentService.modifyComment(1224L, modifyCommentRequestDto, files))
+					.isInstanceOf(NotAllowedModifyWhenNonMemberException.class)
+					.hasMessage("비회원 댓글은 수정 불가능합니다.");
 		}
 
 		@Test


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-185 / 비회원 댓글은 수정 불가능 하도록 변경](https://recodeit.atlassian.net/browse/BE-185)

## 설명
비회원 댓글일 경우 수정 불가능하도록 변경하였습니다

## 변경사항
- [x] `NotAllowedModifyWhenNonMemberException` 생성
- [x] 테스트코드 작성
- [x] 서비스 로직 추가 

## 질문사항
