### PR TITLE
[BE-183] fix: 레코드 삭제와 댓글 삭제 시 이미지 지우는 코드 추가

### DIFF
--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -123,6 +123,7 @@ public class CommentService {
 
 	@Transactional
 	public void deleteComment(Long commentId, DeleteCommentRequestDto deleteCommentRequestDto) {
+		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 
@@ -133,6 +134,8 @@ public class CommentService {
 				.orElseThrow(() -> new CommentNotFoundException("댓글 정보를 가져올 수 없습니다."));
 
 		validateDeleteCommentMatchMember(deleteCommentRequestDto.getRecordId(), member, findComment);
+
+		imageFileService.delete(RefType.COMMENT, commentId);
 		commentRepository.delete(findComment);
 	}
 

--- a/src/main/java/com/recordit/server/service/ImageFileService.java
+++ b/src/main/java/com/recordit/server/service/ImageFileService.java
@@ -119,6 +119,23 @@ public class ImageFileService {
 		}
 	}
 
+	@Transactional
+	public void delete(
+			@NonNull RefType refType,
+			@NonNull Long refId
+	) {
+		List<String> attachmentFileNames = imageFileRepository.findAllByRefTypeAndRefId(refType, refId).stream()
+				.map(ImageFile::getSaveName)
+				.collect(Collectors.toList());
+
+		imageFileRepository.deleteAllByRefTypeAndRefIdAndSaveNameIn(refType, refId, attachmentFileNames);
+
+		for (String attachmentFileName : attachmentFileNames) {
+			s3Uploader.delete(attachmentFileName);
+			log.info("저장한 이미지 파일 삭제 : {}", attachmentFileName);
+		}
+	}
+
 	private void validateImageContentType(MultipartFile multipartFile) {
 		if (!multipartFile.getContentType().startsWith("image")) {
 			log.warn("요청 파일 ContentType : {}", multipartFile.getContentType());

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -67,7 +67,7 @@ public class RecordService {
 	@Transactional
 	public WriteRecordResponseDto writeRecord(WriteRecordRequestDto writeRecordRequestDto,
 			List<MultipartFile> attachments) {
-
+		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 
@@ -212,6 +212,7 @@ public class RecordService {
 
 	@Transactional
 	public void deleteRecord(Long recordId) {
+		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 
@@ -225,6 +226,7 @@ public class RecordService {
 			throw new NotMatchLoginUserWithRecordWriterException("로그인 한 사용자와 글 작성자가 일치하지 않습니다.");
 		}
 
+		imageFileService.delete(RefType.RECORD, recordId);
 		recordRepository.delete(record);
 	}
 


### PR DESCRIPTION
## 관련 이슈 번호
 - [BE-183 / 레코드 삭제와 댓글 삭제 시 이미지 지우는 코드 추가](https://recodeit.atlassian.net/browse/BE-183)

## 설명
레코드 삭제와 댓글 삭제 시 S3에 업로드 되어있는 파일을 지우는 코드를 추가하였습니다

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
