### PR TITLE
[BE-184] 댓글 작성 시 댓글 내용이 있을때만 작성되도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/comment/WriteCommentRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/WriteCommentRequestDto.java
@@ -1,5 +1,6 @@
 package com.recordit.server.dto.comment;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -26,6 +27,7 @@ public class WriteCommentRequestDto {
 
 	@ApiModelProperty(notes = "댓글 내용", required = true)
 	@Size(max = 100, message = "댓글 내용은 100자를 넘길 수 없습니다")
+	@NotBlank(message = "댓글은 빈 값일 수 없습니다")
 	private String comment;
 
 	@Builder

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -124,7 +124,6 @@ public class CommentService {
 
 	@Transactional
 	public void deleteComment(Long commentId, DeleteCommentRequestDto deleteCommentRequestDto) {
-		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -67,7 +67,6 @@ public class RecordService {
 	@Transactional
 	public WriteRecordResponseDto writeRecord(WriteRecordRequestDto writeRecordRequestDto,
 			List<MultipartFile> attachments) {
-		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 
@@ -212,7 +211,6 @@ public class RecordService {
 
 	@Transactional
 	public void deleteRecord(Long recordId) {
-		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-184 / 댓글 작성 시 댓글 내용이 있을때만 작성되도록 변경](https://recodeit.atlassian.net/browse/BE-184)

## 설명
기존 댓글 작성 시 댓글 내용없이 이미지 파일만으로 댓글이 작성 가능하였으나,
정책 변경으로 댓글 내용이 있을때만 댓글을 작성할 수 있도록 변경하였습니다.

## 변경사항

## 질문사항
