### PR TITLE
[BE-187] 댓글 수정 시 파일 단 건으로 받도록 수정

### DIFF
--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -1,7 +1,5 @@
 package com.recordit.server.controller;
 
-import java.util.List;
-
 import javax.validation.Valid;
 
 import org.springframework.http.MediaType;
@@ -123,9 +121,9 @@ public class CommentController {
 	public ResponseEntity modifyComment(
 			@PathVariable("commentId") Long commentId,
 			@ApiParam(required = true) @RequestPart(required = true) @Valid ModifyCommentRequestDto modifyCommentRequestDto,
-			@ApiParam @RequestPart(required = false) List<MultipartFile> attachments
+			@ApiParam @RequestPart(required = false) MultipartFile attachment
 	) {
-		commentService.modifyComment(commentId, modifyCommentRequestDto, attachments);
+		commentService.modifyComment(commentId, modifyCommentRequestDto, attachment);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -181,7 +181,7 @@ public class CommentService {
 	public void modifyComment(
 			Long commentId,
 			ModifyCommentRequestDto modifyCommentRequestDto,
-			List<MultipartFile> attachments
+			MultipartFile attachment
 	) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
@@ -200,8 +200,8 @@ public class CommentService {
 			throw new NotMatchCommentWriterException("로그인한 사용자와 댓글 작성자가 일치하지 않습니다.");
 		}
 
-		if (!imageFileService.isEmptyFile(attachments)) {
-			imageFileService.saveAttachmentFiles(RefType.COMMENT, comment.getId(), attachments);
+		if (!imageFileService.isEmptyFile(attachment)) {
+			imageFileService.saveAttachmentFile(RefType.COMMENT, comment.getId(), attachment);
 		}
 
 		if (modifyCommentRequestDto.getDeleteImages() != null) {

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -3,7 +3,6 @@ package com.recordit.server.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -419,7 +418,7 @@ public class CommentServiceTest {
 		@Mock
 		private Comment mockComment;
 
-		private List<MultipartFile> files = List.of();
+		MockMultipartFile multipartFile = mock(MockMultipartFile.class);
 
 		private final ModifyCommentRequestDto modifyCommentRequestDto = ModifyCommentRequestDto.builder()
 				.comment("수정된 댓글")
@@ -433,7 +432,7 @@ public class CommentServiceTest {
 					.willReturn(Optional.empty());
 
 			// when, then
-			assertThatThrownBy(() -> commentService.modifyComment(153L, modifyCommentRequestDto, files))
+			assertThatThrownBy(() -> commentService.modifyComment(153L, modifyCommentRequestDto, multipartFile))
 					.isInstanceOf(MemberNotFoundException.class)
 					.hasMessage("회원 정보를 찾을 수 없습니다.");
 		}
@@ -448,7 +447,7 @@ public class CommentServiceTest {
 					.willReturn(Optional.empty());
 
 			// when, then
-			assertThatThrownBy(() -> commentService.modifyComment(124L, modifyCommentRequestDto, files))
+			assertThatThrownBy(() -> commentService.modifyComment(124L, modifyCommentRequestDto, multipartFile))
 					.isInstanceOf(CommentNotFoundException.class)
 					.hasMessage("댓글 정보를 가져올 수 없습니다.");
 		}
@@ -465,7 +464,7 @@ public class CommentServiceTest {
 					.willReturn(null);
 
 			// when, then
-			assertThatThrownBy(() -> commentService.modifyComment(1224L, modifyCommentRequestDto, files))
+			assertThatThrownBy(() -> commentService.modifyComment(1224L, modifyCommentRequestDto, multipartFile))
 					.isInstanceOf(NotAllowedModifyWhenNonMemberException.class)
 					.hasMessage("비회원 댓글은 수정 불가능합니다.");
 		}
@@ -486,7 +485,7 @@ public class CommentServiceTest {
 					.willReturn(2L);
 
 			// when, then
-			assertThatThrownBy(() -> commentService.modifyComment(1123L, modifyCommentRequestDto, files))
+			assertThatThrownBy(() -> commentService.modifyComment(1123L, modifyCommentRequestDto, multipartFile))
 					.isInstanceOf(NotMatchCommentWriterException.class)
 					.hasMessage("로그인한 사용자와 댓글 작성자가 일치하지 않습니다.");
 		}
@@ -505,7 +504,7 @@ public class CommentServiceTest {
 					.willReturn(1L);
 
 			// when, then
-			assertThatCode(() -> commentService.modifyComment(1123L, modifyCommentRequestDto, files))
+			assertThatCode(() -> commentService.modifyComment(1123L, modifyCommentRequestDto, multipartFile))
 					.doesNotThrowAnyException();
 		}
 	}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-187 / 댓글 수정 시 파일 단 건으로 받도록 수정](https://recodeit.atlassian.net/browse/BE-187)

## 설명
댓글 수정 시 파일을 여러개를 받도록 되어있던걸 단 건으로 받도록 변경하였습니다.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
