### PR TITLE
[BE-188] refactor : 추억레코드 조회시 오늘 날짜의 레코드도 조회되도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -21,7 +21,13 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			+ "left join r.writer "
 			+ "left join r.recordColor "
 			+ "left join r.recordIcon "
-			+ "where r.writer = :writer and r.createdAt < :dateTime ")
+			+ "where r.writer = :writer and r.createdAt < "
+			+ "("
+			+ "select coalesce(max(r.createdAt), :dateTime)"
+			+ "from RECORD r "
+			+ "where r.createdAt >= :dateTime"
+			+ ") "
+	)
 	Page<Record> findByWriterFetchAllCreatedAtBefore(
 			@Param("writer") Member writer,
 			@Param("dateTime") LocalDateTime dateTime,


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-188 / 추억레코드 조회시 오늘 날짜의 레코드도 조회되도록 변경](https://recodeit.atlassian.net/browse/BE-188)
## 설명
추억레코드 조회시 오늘 날짜의 레코드도 조회되도록 변경(단, 오늘 작성한 가장 최신의 레코드는 제외)
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
