### PR TITLE
[BE-189] 서버 모니터링을 위한 actuator prometheus 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ dependencies {
     // log4j2
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus:latest.release'
+    testImplementation 'io.micrometer:micrometer-registry-elastic:latest.release'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/SwaggerConfiguration.java
@@ -1,7 +1,25 @@
 package com.recordit.server.configuration;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
+import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -28,5 +46,38 @@ public class SwaggerConfiguration {
 				.description("RecordIt Backend - DEV 서버 API 명세")
 				.version("1.0")
 				.build();
+	}
+
+	@Bean
+	public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(
+			WebEndpointsSupplier webEndpointsSupplier,
+			ServletEndpointsSupplier servletEndpointsSupplier,
+			ControllerEndpointsSupplier controllerEndpointsSupplier,
+			EndpointMediaTypes endpointMediaTypes,
+			CorsEndpointProperties corsProperties,
+			WebEndpointProperties webEndpointProperties,
+			Environment environment
+	) {
+		List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+		Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+		allEndpoints.addAll(webEndpoints);
+		allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+		allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+		String basePath = webEndpointProperties.getBasePath();
+		EndpointMapping endpointMapping = new EndpointMapping(basePath);
+		boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment,
+				basePath);
+		return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
+				corsProperties.toCorsConfiguration()
+				, new EndpointLinksResolver(allEndpoints, basePath), shouldRegisterLinksMapping, null);
+	}
+
+	private boolean shouldRegisterLinksMapping(
+			WebEndpointProperties webEndpointProperties,
+			Environment environment,
+			String basePath
+	) {
+		return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath)
+				|| ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
 	}
 }

--- a/src/main/java/com/recordit/server/logger/HTTPLogFilter.java
+++ b/src/main/java/com/recordit/server/logger/HTTPLogFilter.java
@@ -69,6 +69,12 @@ public class HTTPLogFilter implements Filter {
 		if ("/v2/api-docs".equals(requestWrapper.getRequestURI())) {
 			return true;
 		}
+		if ("/actuator/prometheus".equals(requestWrapper.getRequestURI())) {
+			return true;
+		}
+		if ("/".equals(requestWrapper.getRequestURI())) {
+			return true;
+		}
 		return false;
 	}
 

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: "actuator"
+
+management:
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: info, health, prometheus
+      base-path: /api/actuator/recordIt
+
+  endpoint:
+    info:
+      enabled: true
+    health:
+      enabled: true
+    prometheus:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
       "test": "test"
       "local": "local, datasource, redis, oauth, s3"
       "dev": "dev, datasource, redis, oauth, s3"
-      "prod": "prod, datasource, redis, oauth, s3"
+      "prod": "prod, datasource, redis, oauth, s3, actuator"


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-189 / 서버 모니터링을 위한 actuator prometheus 설정](https://recodeit.atlassian.net/browse/BE-189)

## 설명
prod 환경 actuator, prometheus 설정 추가하였습니다.
swagger버전 이슈로 인해 actuator 의존성 추가 시 run 되지않는 문제를 [config 설정](https://jaimemin.tistory.com/2187)을 통해 해결하였습니다


## 변경사항
- [x] build.gradle에 actuator과 prometheus 의존성 추가
- [x] actuator.yml 생성 / prod 환경에서만 사용하도록 설정
- [x] swagger config 설정 추가

## 질문사항
