### PR TITLE
[BE-193] 랜덤으로 레코드 조회

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
+import com.recordit.server.dto.record.RandomRecordRequestDto;
+import com.recordit.server.dto.record.RandomRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordByDateResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
@@ -170,5 +172,27 @@ public class RecordController {
 			@ApiParam @RequestPart(required = false) List<MultipartFile> attachments
 	) {
 		return ResponseEntity.ok().body(recordService.modifyRecord(recordId, modifyRecordRequestDto, attachments));
+	}
+
+	@ApiOperation(
+			value = "레코드 랜덤 조회",
+			notes = "레코드를 랜덤으로 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "레코드 랜덤 조회 성공",
+					response = RandomRecordResponseDto.class
+			),
+			@ApiResponse(
+					code = 400,
+					message = "잘못 된 요청",
+					response = ErrorMessage.class
+			)
+	})
+	@GetMapping("/random")
+	public ResponseEntity<List<RandomRecordResponseDto>> getRandomRecord(
+			@ModelAttribute @Valid RandomRecordRequestDto randomRecordRequestDto
+	) {
+		return ResponseEntity.ok(recordService.getRandomRecord(randomRecordRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/RandomRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RandomRecordRequestDto.java
@@ -1,0 +1,26 @@
+package com.recordit.server.dto.record;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiParam;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class RandomRecordRequestDto {
+	@ApiParam(value = "카테고리 ID", required = true, example = "1")
+	@NotNull
+	private Long recordCategoryId;
+
+	@ApiParam(value = "댓글 리스트의 사이즈", required = true, example = "5")
+	@NotNull
+	private Integer size;
+}

--- a/src/main/java/com/recordit/server/dto/record/RandomRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RandomRecordResponseDto.java
@@ -1,0 +1,46 @@
+package com.recordit.server.dto.record;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiParam;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class RandomRecordResponseDto {
+	@ApiParam(value = "레코드 ID", required = true)
+	private Long recordId;
+
+	@ApiParam(value = "레코드 제목", required = true)
+	private String title;
+
+	@ApiParam(value = "레코드 컬러명", required = true)
+	private String colorName;
+
+	@ApiParam(value = "레코드 아이콘명", required = true)
+	private String iconName;
+
+	@ApiParam(value = "댓글 개수", required = true)
+	private Long commentCount;
+
+	public static RandomRecordResponseDto of(
+			Record record,
+			Long commentCount
+	) {
+		return RandomRecordResponseDto.builder()
+				.recordId(record.getId())
+				.title(record.getTitle())
+				.colorName(record.getRecordColor().getName())
+				.iconName(record.getRecordIcon().getName())
+				.commentCount(commentCount)
+				.build();
+	}
+}

--- a/src/main/java/com/recordit/server/repository/CommentRepository.java
+++ b/src/main/java/com/recordit/server/repository/CommentRepository.java
@@ -26,4 +26,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Long countAllByParentComment(Comment parentComment);
 
 	List<Comment> findAllByRecord(Record record, Pageable pageable);
+
+	Long countByRecordId(Long recordId);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -1,6 +1,7 @@
 package com.recordit.server.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -52,4 +53,13 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
 	@Query("select r from RECORD r join fetch r.writer where r.id = :id")
 	Optional<Record> findByIdFetchWriter(Long id);
+
+	@Query(value = "select * from RECORD r "
+			+ "where r.DELETED_AT is null "
+			+ "and r.RECORD_CATEGORY_ID IN ("
+			+ "select c.RECORD_CATEGORY_ID "
+			+ "from RECORD_CATEGORY c where c.PARENT_RECORD_CATEGORY_ID = :categoryId"
+			+ ") "
+			+ "order by RAND() limit :size", nativeQuery = true)
+	List<Record> findTopSizeRandomRecordByRecordCategoryId(Integer size, Long categoryId);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -1,5 +1,6 @@
 package com.recordit.server.service;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,8 @@ import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.domain.RecordColor;
 import com.recordit.server.domain.RecordIcon;
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
+import com.recordit.server.dto.record.RandomRecordRequestDto;
+import com.recordit.server.dto.record.RandomRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordByDateResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
@@ -267,5 +270,23 @@ public class RecordService {
 		}
 
 		return record.modify(modifyRecordRequestDto, recordColor, recordIcon);
+	}
+
+	public List<RandomRecordResponseDto> getRandomRecord(
+			RandomRecordRequestDto randomRecordRequestDto
+	) {
+		RecordCategory recordCategory = recordCategoryRepository.findById(randomRecordRequestDto.getRecordCategoryId())
+				.orElseThrow(() -> new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다."));
+
+		List<Record> recordList = recordRepository.findTopSizeRandomRecordByRecordCategoryId(
+				randomRecordRequestDto.getSize(),
+				recordCategory.getId()
+		);
+		List<RandomRecordResponseDto> randomRecords = new ArrayList<>();
+		for (Record record : recordList) {
+			Long commentCount = commentRepository.countByRecordId(record.getId());
+			randomRecords.add(RandomRecordResponseDto.of(record, commentCount));
+		}
+		return randomRecords;
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -3,6 +3,7 @@ package com.recordit.server.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import com.recordit.server.domain.RecordCategory;
 import com.recordit.server.domain.RecordColor;
 import com.recordit.server.domain.RecordIcon;
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
+import com.recordit.server.dto.record.RandomRecordRequestDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
@@ -482,6 +484,41 @@ class RecordServiceTest {
 
 			// when, then
 			assertThatCode(() -> recordService.modifyRecord(12L, modifyRecordRequestDto, files))
+					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("랜덤 레코드를 조회 할 때")
+	class 랜덤_레코드를_죠회_할_때 {
+		private final RandomRecordRequestDto randomRecordRequestDto = RandomRecordRequestDto
+				.builder()
+				.recordCategoryId(1L)
+				.size(5)
+				.build();
+
+		@Test
+		@DisplayName("레코드 카테고리를 찾지 못한다면 예외를 던진다")
+		void 레코드_카테고리를_찾지_못한다면_예외를_던진다() {
+			// given
+			given(recordCategoryRepository.findById(anyLong()))
+					.willReturn(Optional.empty());
+			// when, then
+			assertThatThrownBy(() -> recordService.getRandomRecord(randomRecordRequestDto))
+					.isInstanceOf(RecordCategoryNotFoundException.class)
+					.hasMessage("카테고리 정보를 찾을 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("정상적이라면 예외를 던지지 않는다")
+		void 정상적이라면_예외를_던지지_않는다() {
+			// given
+			given(recordCategoryRepository.findById(anyLong()))
+					.willReturn(Optional.of(mockRecordCategory));
+			given(recordRepository.findTopSizeRandomRecordByRecordCategoryId(any(), anyLong()))
+					.willReturn(new ArrayList<>());
+			// when, then
+			assertThatCode(() -> recordService.getRandomRecord(randomRecordRequestDto))
 					.doesNotThrowAnyException();
 		}
 	}


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-193 / 랜덤으로 레코드 조회](https://recodeit.atlassian.net/browse/BE-193)

## 설명
랜덤으로 레코드르 조회하는 기능입니다.
카테고리에 따라 분류되기 때문에 request에서 categoryId와 size를 받아옵니다.
랜덤 추출은 데이터베이스에 RAND() 함수를 사용하였고, RAND()함수를 사용하려면 nativeQuery를 true로 설정해줘야 했습니다.

## 변경사항

## 질문사항
현재 카테고리에 맞는 레코드들 N개 만큼 가져와서 (쿼리 1번)
각 레코드마다 댓글의 카운트를 조회(쿼리 N번)를 하는 상황입니다.
SQL로 쿼리는 짜두었습니다