### PR TITLE
[BE-194]  추억레코드에서 대댓글은 안보이도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/repository/CommentRepository.java
+++ b/src/main/java/com/recordit/server/repository/CommentRepository.java
@@ -25,7 +25,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Long countAllByParentComment(Comment parentComment);
 
-	List<Comment> findAllByRecord(Record record, Pageable pageable);
+	List<Comment> findAllByRecordAndParentCommentIsNull(Record record, Pageable pageable);
 
 	Long countByRecordId(Long recordId);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -194,7 +194,7 @@ public class RecordService {
 					// key
 					findRecord,
 					// value
-					commentRepository.findAllByRecord(
+					commentRepository.findAllByRecordAndParentCommentIsNull(
 							findRecord,
 							PageRequest.of(
 									FIRST_PAGE,


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-194/ 추억레코드에서 대댓글은 안보이도록 변경](https://recodeit.atlassian.net/browse/BE-194)
## 설명
추억레코드에서 대댓글은 안보이도록 수정하였습니다.
CommentRepository의 findAllByRecord 메소드를 findAllByRecordAndParentCommentIsNull 로 변경하여 대댓글은 조회되지않도록 수정
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
