### PR TITLE
[BE-199] 모아보기 최신레코드

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordResponseDto;
+import com.recordit.server.dto.record.RecentRecordRequestDto;
+import com.recordit.server.dto.record.RecentRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordByDateResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
@@ -172,7 +175,8 @@ public class RecordController {
 			@ApiParam(required = true) @RequestPart(required = true) @Valid ModifyRecordRequestDto modifyRecordRequestDto,
 			@ApiParam @RequestPart(required = false) List<MultipartFile> attachments
 	) {
-		return ResponseEntity.ok().body(recordService.modifyRecord(recordId, modifyRecordRequestDto, attachments));
+		return ResponseEntity.ok()
+				.body(recordService.modifyRecord(recordId, modifyRecordRequestDto, attachments));
 	}
 
 	@ApiOperation(
@@ -200,5 +204,21 @@ public class RecordController {
 	@GetMapping("/mix")
 	public ResponseEntity<MixRecordResponseDto> getMixRecords() {
 		return ResponseEntity.ok().body(recordService.getMixRecords());
+	}
+
+	@ApiOperation(
+			value = "최신 레코드 조회",
+			notes = "최신의 레코드를 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "최신 레코드 조회 성공"
+			)
+	})
+	@GetMapping("/recent")
+	public ResponseEntity<Page<RecentRecordResponseDto>> getRecentRecord(
+			@ModelAttribute @Valid RecentRecordRequestDto recentRecordRequestDto
+	) {
+		return ResponseEntity.ok(recordService.getRecentRecord(recentRecordRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -175,8 +175,7 @@ public class RecordController {
 			@ApiParam(required = true) @RequestPart(required = true) @Valid ModifyRecordRequestDto modifyRecordRequestDto,
 			@ApiParam @RequestPart(required = false) List<MultipartFile> attachments
 	) {
-		return ResponseEntity.ok()
-				.body(recordService.modifyRecord(recordId, modifyRecordRequestDto, attachments));
+		return ResponseEntity.ok().body(recordService.modifyRecord(recordId, modifyRecordRequestDto, attachments));
 	}
 
 	@ApiOperation(

--- a/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
@@ -1,0 +1,30 @@
+package com.recordit.server.dto.record;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiParam;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class RecentRecordRequestDto {
+
+	@ApiParam(value = "페이지 번호", required = true, example = "0")
+	@NotNull
+	@Min(0)
+	private Integer page;
+
+	@ApiParam(value = "최신 레코드 갯수", required = true, example = "1")
+	@NotNull
+	@Min(1)
+	private Integer size;
+}

--- a/src/main/java/com/recordit/server/dto/record/RecentRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecentRecordResponseDto.java
@@ -1,0 +1,50 @@
+package com.recordit.server.dto.record;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiParam;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class RecentRecordResponseDto {
+	@ApiParam(value = "레코드 ID", required = true)
+	private Long recordId;
+
+	@ApiParam(value = "레코드 제목", required = true)
+	private String title;
+
+	@ApiParam(value = "레코드 컬러명", required = true)
+	private String colorName;
+
+	@ApiParam(value = "레코드 아이콘명", required = true)
+	private String iconName;
+
+	@ApiParam(value = "댓글 개수", required = true)
+	private Long commentCount;
+
+	private RecentRecordResponseDto(Long recordId, String title, String colorName, String iconName,
+			Long commentCount) {
+		this.recordId = recordId;
+		this.title = title;
+		this.colorName = colorName;
+		this.iconName = iconName;
+		this.commentCount = commentCount;
+	}
+
+	public static RecentRecordResponseDto of(
+			Record record,
+			Long commentCount
+	) {
+		return new RecentRecordResponseDto(
+				record.getId(),
+				record.getTitle(),
+				record.getRecordColor().getName(),
+				record.getRecordIcon().getName(),
+				commentCount
+		);
+	}
+}

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -62,4 +62,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			+ ") "
 			+ "order by RAND() limit :size", nativeQuery = true)
 	List<Record> findRandomRecordByRecordCategoryId(Integer size, Long categoryId);
+
+	@EntityGraph(attributePaths = {"recordIcon", "recordColor"})
+	Page<Record> findAll(Pageable pageable);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -64,5 +64,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	List<Record> findRandomRecordByRecordCategoryId(Integer size, Long categoryId);
 
 	@EntityGraph(attributePaths = {"recordIcon", "recordColor"})
-	Page<Record> findAll(Pageable pageable);
+	@Query(value = "select r from RECORD r "
+			+ "where r.deletedAt is null")
+	Page<Record> findAllFetchRecordIconAndRecordColor(Pageable pageable);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -84,12 +84,10 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		RecordCategory recordCategory = recordCategoryRepository.findById(
-						writeRecordRequestDto.getRecordCategoryId())
+		RecordCategory recordCategory = recordCategoryRepository.findById(writeRecordRequestDto.getRecordCategoryId())
 				.orElseThrow(() -> new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(
-						writeRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(writeRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
 		RecordIcon recordIcon = recordIconRepository.findByName(writeRecordRequestDto.getIconName())
@@ -107,8 +105,7 @@ public class RecordService {
 		log.info("저장한 레코드 ID : {}", saveRecord.getId());
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD,
-					saveRecord.getId(), attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, saveRecord.getId(), attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 
@@ -257,12 +254,10 @@ public class RecordService {
 		Record record = recordRepository.findByIdFetchWriter(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(
-						modifyRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(modifyRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
-		RecordIcon recordIcon = recordIconRepository.findByName(
-						modifyRecordRequestDto.getIconName())
+		RecordIcon recordIcon = recordIconRepository.findByName(modifyRecordRequestDto.getIconName())
 				.orElseThrow(() -> new RecordIconNotFoundException("아이콘 정보를 찾을 수 없습니다."));
 
 		if (record.getWriter().getId() != member.getId()) {
@@ -270,8 +265,7 @@ public class RecordService {
 		}
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(),
-					attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(), attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -333,16 +333,20 @@ public class RecordService {
 	public Page<RecentRecordResponseDto> getRecentRecord(
 			RecentRecordRequestDto recentRecordRequestDto
 	) {
-		Page<Record> recordPage = recordRepository.findAll(PageRequest.of(
-				recentRecordRequestDto.getPage(),
-				recentRecordRequestDto.getSize(),
-				Sort.Direction.DESC,
-				"createdAt"
-		));
+		Page<Record> recordPage = recordRepository.findAllFetchRecordIconAndRecordColor(
+				PageRequest.of(
+						recentRecordRequestDto.getPage(),
+						recentRecordRequestDto.getSize(),
+						Sort.Direction.DESC,
+						"createdAt"
+				)
+		);
 
-		return recordPage.map(record -> RecentRecordResponseDto.of(
-				record,
-				commentRepository.countByRecordId(record.getId())
-		));
+		return recordPage.map(
+				record -> RecentRecordResponseDto.of(
+						record,
+						commentRepository.countByRecordId(record.getId())
+				)
+		);
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -620,7 +620,8 @@ class RecordServiceTest {
 					.willReturn(new PageImpl<>(recordList, pageRequest, 1));
 			//when
 			Page<RecentRecordResponseDto> recentRecord = recordService.getRecentRecord(
-					recentRecordRequestDto);
+					recentRecordRequestDto
+			);
 			//then
 			assertEquals(1, recentRecord.getTotalElements());
 			assertEquals(23L, recentRecord.getContent().get(0).getRecordId());

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -1,6 +1,7 @@
 package com.recordit.server.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.ArrayList;
@@ -15,6 +16,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +31,8 @@ import com.recordit.server.domain.RecordColor;
 import com.recordit.server.domain.RecordIcon;
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordRequestDto;
+import com.recordit.server.dto.record.RecentRecordRequestDto;
+import com.recordit.server.dto.record.RecentRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
@@ -554,6 +561,72 @@ class RecordServiceTest {
 			//when, then
 			assertThatCode(() -> recordService.getMixRecords())
 					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("최신 레코드를 조회_할 때")
+	class 최신_레코드를_조회_할_때 {
+		RecentRecordRequestDto recentRecordRequestDto = RecentRecordRequestDto.builder()
+				.page(0)
+				.size(10)
+				.build();
+
+		@Test
+		@DisplayName("비어있다면 아무것도 조회되지 않는다")
+		void 비어있다면_아무것도_조회되지_않는다() {
+			//given
+			PageRequest pageRequest = PageRequest.of(
+					recentRecordRequestDto.getPage(),
+					recentRecordRequestDto.getSize(),
+					Sort.Direction.DESC,
+					"createdAt"
+			);
+
+			given(recordRepository.findAll(pageRequest))
+					.willReturn(new PageImpl<>(List.of(), pageRequest, 0));
+			//when
+			Page<RecentRecordResponseDto> recentRecord = recordService.getRecentRecord(
+					recentRecordRequestDto);
+			//then
+			assertEquals(0, recentRecord.getTotalElements());
+		}
+
+		@Test
+		@DisplayName("비어있지 않다면 정상적으로 조회된다")
+		void 비어있지_않다면_정상적으로_조회된다() {
+			//given
+			List<Record> recordList = List.of(mockRecord);
+			PageRequest pageRequest = PageRequest.of(
+					recentRecordRequestDto.getPage(),
+					recentRecordRequestDto.getSize(),
+					Sort.Direction.DESC,
+					"createdAt"
+			);
+			given(mockRecord.getRecordColor())
+					.willReturn(mockRecordColor);
+			given(mockRecord.getRecordIcon())
+					.willReturn(mockRecordIcon);
+			given(mockRecord.getId())
+					.willReturn(23L);
+			given(mockRecord.getTitle())
+					.willReturn("레코드 제목입니다");
+
+			given(mockRecordColor.getName())
+					.willReturn("color");
+			given(mockRecordIcon.getName())
+					.willReturn("icon");
+			given(recordRepository.findAll(pageRequest))
+					.willReturn(new PageImpl<>(recordList, pageRequest, 1));
+			//when
+			Page<RecentRecordResponseDto> recentRecord = recordService.getRecentRecord(
+					recentRecordRequestDto);
+			//then
+			assertEquals(1, recentRecord.getTotalElements());
+			assertEquals(23L, recentRecord.getContent().get(0).getRecordId());
+			assertEquals("레코드 제목입니다", recentRecord.getContent().get(0).getTitle());
+			assertEquals("color", recentRecord.getContent().get(0).getColorName());
+			assertEquals("icon", recentRecord.getContent().get(0).getIconName());
 		}
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-199 / 모아보기 최신레코드](https://recodeit.atlassian.net/browse/BE-199)

## 설명
모아보기 탭에서 최신레코드 반환하는 API입니다.
테스트 코드 작성 시 기존 예외만 테스트 하던 내용이 해당 메서드에서는 의미가 없다고 생각하여 mock처리 후 데이터 검증하였습니다.
Swagger `@ApiResponse`에서 response를 Page객체로 반환해주어야 했는데 `Page<responseDto>.class` 의 형태가 되지 않아 작성하지 않았더니 정상 응답 형태로 나옵니당.

## 변경사항
- [x] 최신 레코드 조회 테스트 코드 작성
- [x] RecentRecordRequest, Response Dto 생성
- [x] RecordService.java에서 getRecentRecord 메서드 생성 (최신 레코드 조회 비지니스 로직) 

## 질문사항
10개의 레코드를 가져온 후 각각 댓글의 카운트를 찾아야해서 `N+1` 문제 발생합니다. 좋은 방법이 있다면 알려주신다면 적극 반영하겠습니다.