### PR TITLE
[BE-203] getRandomRecord에서 Transactional readonly 속성 부여

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -82,10 +82,12 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		RecordCategory recordCategory = recordCategoryRepository.findById(writeRecordRequestDto.getRecordCategoryId())
+		RecordCategory recordCategory = recordCategoryRepository.findById(
+						writeRecordRequestDto.getRecordCategoryId())
 				.orElseThrow(() -> new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(writeRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(
+						writeRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
 		RecordIcon recordIcon = recordIconRepository.findByName(writeRecordRequestDto.getIconName())
@@ -103,7 +105,8 @@ public class RecordService {
 		log.info("저장한 레코드 ID : {}", saveRecord.getId());
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, saveRecord.getId(), attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD,
+					saveRecord.getId(), attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 
@@ -252,10 +255,12 @@ public class RecordService {
 		Record record = recordRepository.findByIdFetchWriter(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(modifyRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(
+						modifyRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
-		RecordIcon recordIcon = recordIconRepository.findByName(modifyRecordRequestDto.getIconName())
+		RecordIcon recordIcon = recordIconRepository.findByName(
+						modifyRecordRequestDto.getIconName())
 				.orElseThrow(() -> new RecordIconNotFoundException("아이콘 정보를 찾을 수 없습니다."));
 
 		if (record.getWriter().getId() != member.getId()) {
@@ -263,7 +268,8 @@ public class RecordService {
 		}
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(), attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(),
+					attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 
@@ -278,7 +284,7 @@ public class RecordService {
 		return record.modify(modifyRecordRequestDto, recordColor, recordIcon);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public List<RandomRecordResponseDto> getRandomRecord(
 			RandomRecordRequestDto randomRecordRequestDto
 	) {

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -82,12 +82,10 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		RecordCategory recordCategory = recordCategoryRepository.findById(
-						writeRecordRequestDto.getRecordCategoryId())
+		RecordCategory recordCategory = recordCategoryRepository.findById(writeRecordRequestDto.getRecordCategoryId())
 				.orElseThrow(() -> new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(
-						writeRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(writeRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
 		RecordIcon recordIcon = recordIconRepository.findByName(writeRecordRequestDto.getIconName())
@@ -105,8 +103,7 @@ public class RecordService {
 		log.info("저장한 레코드 ID : {}", saveRecord.getId());
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD,
-					saveRecord.getId(), attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, saveRecord.getId(), attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 
@@ -255,12 +252,10 @@ public class RecordService {
 		Record record = recordRepository.findByIdFetchWriter(recordId)
 				.orElseThrow(() -> new RecordNotFoundException("레코드 정보를 찾을 수 없습니다."));
 
-		RecordColor recordColor = recordColorRepository.findByName(
-						modifyRecordRequestDto.getColorName())
+		RecordColor recordColor = recordColorRepository.findByName(modifyRecordRequestDto.getColorName())
 				.orElseThrow(() -> new RecordColorNotFoundException("컬러 정보를 찾을 수 없습니다."));
 
-		RecordIcon recordIcon = recordIconRepository.findByName(
-						modifyRecordRequestDto.getIconName())
+		RecordIcon recordIcon = recordIconRepository.findByName(modifyRecordRequestDto.getIconName())
 				.orElseThrow(() -> new RecordIconNotFoundException("아이콘 정보를 찾을 수 없습니다."));
 
 		if (record.getWriter().getId() != member.getId()) {
@@ -268,8 +263,7 @@ public class RecordService {
 		}
 
 		if (!imageFileService.isEmptyFile(attachments)) {
-			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(),
-					attachments);
+			List<String> urls = imageFileService.saveAttachmentFiles(RefType.RECORD, record.getId(), attachments);
 			log.info("저장된 이미지 urls : {}", urls);
 		}
 


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-203 / getRandomRecord에서 Reansactional readonly 속성 부여](https://recodeit.atlassian.net/browse/BE-203)

## 설명
RecordService.java 파일에서 getRandomRecord메서드의 `@Transactional` 어노테이션의 `(readOnly = true)`속성이 누락되어있어 추가하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항