### PR TITLE
[BE-195] 카테고리 조회 로직에서 부모 id를 통해 조회하도록 수정

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.recordit.server.dto.record.category.RecordCategoryResponseDto;
@@ -15,6 +16,7 @@ import com.recordit.server.dto.record.category.SaveRecordCategoryRequestDto;
 import com.recordit.server.service.RecordCategoryService;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +29,10 @@ public class RecordCategoryController {
 	private final RecordCategoryService recordCategoryService;
 
 	@ApiOperation(
-			value = "레코드 카테고리 전체 조회",
-			notes = "레코드 카테고리 전체를 조회합니다."
+			value = "레코드 카테고리 조회",
+			notes = "레코드 카테고리를 조회합니다. \t\n"
+					+ "부모 카테고리를 지정하지 않으면 상위 카테고리를 반환하고, \t\n"
+					+ "부모 카테고리를 지정하면 해당 부모의 하위 카테고리를 반환합니다."
 	)
 	@ApiResponses({
 			@ApiResponse(
@@ -37,8 +41,10 @@ public class RecordCategoryController {
 			)
 	})
 	@GetMapping
-	public ResponseEntity<List<RecordCategoryResponseDto>> getAllRecordCategories() {
-		return ResponseEntity.ok(recordCategoryService.getAllRecordCategories());
+	public ResponseEntity<List<RecordCategoryResponseDto>> getAllRecordCategories(
+			@ApiParam(value = "조회할 카테고리의 부모 ID") @RequestParam(required = false) Long parentRecordCategoryId
+	) {
+		return ResponseEntity.ok(recordCategoryService.getSubCategories(parentRecordCategoryId));
 	}
 
 	@PostMapping

--- a/src/main/java/com/recordit/server/controller/RecordCategoryController.java
+++ b/src/main/java/com/recordit/server/controller/RecordCategoryController.java
@@ -44,7 +44,7 @@ public class RecordCategoryController {
 	public ResponseEntity<List<RecordCategoryResponseDto>> getAllRecordCategories(
 			@ApiParam(value = "조회할 카테고리의 부모 ID") @RequestParam(required = false) Long parentRecordCategoryId
 	) {
-		return ResponseEntity.ok(recordCategoryService.getSubCategories(parentRecordCategoryId));
+		return ResponseEntity.ok(recordCategoryService.getCategories(parentRecordCategoryId));
 	}
 
 	@PostMapping

--- a/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/category/RecordCategoryResponseDto.java
@@ -1,14 +1,13 @@
 package com.recordit.server.dto.record.category;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.recordit.server.domain.RecordCategory;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -25,13 +24,16 @@ public class RecordCategoryResponseDto {
 	@ApiModelProperty(notes = "레코드 카테고리 이름", required = true)
 	private String name;
 
-	@ApiModelProperty(notes = "하위 레코드 목록", required = true)
-	private List<RecordCategoryResponseDto> subcategories = new ArrayList<>();
+	private RecordCategoryResponseDto(Long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
 
-	@Builder
-	public RecordCategoryResponseDto(RecordCategory recordCategory, List<RecordCategoryResponseDto> children) {
-		this.id = recordCategory.getId();
-		this.name = recordCategory.getName();
-		this.subcategories = children;
+	public static RecordCategoryResponseDto of(RecordCategory recordCategory) {
+		return new RecordCategoryResponseDto(recordCategory.getId(), recordCategory.getName());
+	}
+
+	public static List<RecordCategoryResponseDto> of(List<RecordCategory> recordCategories) {
+		return recordCategories.stream().map(RecordCategoryResponseDto::of).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
@@ -3,12 +3,9 @@ package com.recordit.server.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.recordit.server.domain.RecordCategory;
 
 public interface RecordCategoryRepository extends JpaRepository<RecordCategory, Long> {
-
-	@Query("select rc from RECORD_CATEGORY rc left join fetch rc.parentRecordCategory")
-	List<RecordCategory> findAllFetchDepthIsOne();
+	List<RecordCategory> findAllByParentRecordCategory(RecordCategory parentRecordCategory);
 }

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -23,7 +23,7 @@ public class RecordCategoryService {
 
 	@Transactional(readOnly = true)
 	@Cacheable(value = "Categories")
-	public List<RecordCategoryResponseDto> getSubCategories(Long parentRecordCategoryId) {
+	public List<RecordCategoryResponseDto> getCategories(Long parentRecordCategoryId) {
 
 		RecordCategory parentRecordCategory = null;
 		if (parentRecordCategoryId != null) {

--- a/src/main/java/com/recordit/server/service/RecordCategoryService.java
+++ b/src/main/java/com/recordit/server/service/RecordCategoryService.java
@@ -1,10 +1,6 @@
 package com.recordit.server.service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -27,43 +23,20 @@ public class RecordCategoryService {
 
 	@Transactional(readOnly = true)
 	@Cacheable(value = "Categories")
-	public List<RecordCategoryResponseDto> getAllRecordCategories() {
-		List<RecordCategory> findRecordCategories = recordCategoryRepository.findAllFetchDepthIsOne();
+	public List<RecordCategoryResponseDto> getSubCategories(Long parentRecordCategoryId) {
 
-		LinkedHashMap<RecordCategory, List<RecordCategory>> parentToChildren = new LinkedHashMap<>();
-
-		// 부모이면서 자식이 null이 아닌 Map 생성
-		parentToChildren.putAll(findRecordCategories.stream()
-				.filter(recordCategory -> recordCategory.getParentRecordCategory() != null)
-				.collect(Collectors.groupingBy(RecordCategory::getParentRecordCategory)));
-
-		// 부모이면서 자식이 null인 객체 Map에 추가
-		findRecordCategories.stream()
-				.filter(recordCategory -> recordCategory.getParentRecordCategory() == null)
-				.forEach(recordCategory -> parentToChildren.putIfAbsent(recordCategory, Collections.emptyList()));
-
-		List<RecordCategoryResponseDto> result = new ArrayList<>();
-		for (RecordCategory parent : parentToChildren.keySet()) {
-			// 자식 객체들을 자식 DTO List로 변환
-			List<RecordCategoryResponseDto> children = parentToChildren.get(parent)
-					.stream()
-					.map(
-							child -> RecordCategoryResponseDto.builder()
-									.recordCategory(child)
-									.children(Collections.emptyList())
-									.build()
-					)
-					.collect(Collectors.toList());
-
-			// 자식 DTO 객체들을 부모 DTO 객체에 추가 후 result에 담음
-			RecordCategoryResponseDto parentDto = RecordCategoryResponseDto.builder()
-					.recordCategory(parent)
-					.children(children)
-					.build();
-			result.add(parentDto);
+		RecordCategory parentRecordCategory = null;
+		if (parentRecordCategoryId != null) {
+			parentRecordCategory = recordCategoryRepository.findById(parentRecordCategoryId)
+					.orElseThrow(() -> new RecordCategoryNotFoundException("지정한 카테고리가 존재하지 않습니다."));
+			validateParentHasParent(parentRecordCategory);
 		}
 
-		return result;
+		List<RecordCategory> findRecordCategories = recordCategoryRepository.findAllByParentRecordCategory(
+				parentRecordCategory
+		);
+
+		return RecordCategoryResponseDto.of(findRecordCategories);
 	}
 
 	@CacheEvict(value = "Categories", allEntries = true)
@@ -81,5 +54,11 @@ public class RecordCategoryService {
 
 		RecordCategory recordCategory = RecordCategory.of(parentRecordCategory, saveRecordCategoryRequestDto.getName());
 		recordCategoryRepository.save(recordCategory);
+	}
+
+	private void validateParentHasParent(RecordCategory parentRecordCategory) {
+		if (parentRecordCategory.getParentRecordCategory() != null) {
+			throw new HaveParentRecordCategoryException("부모 카테고리는 부모 카테고리를 가질 수 없습니다.");
+		}
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
@@ -49,7 +49,7 @@ class RecordCategoryServiceTest {
 					.willReturn(grandParentRecordCategory);
 
 			// when, then
-			assertThatThrownBy(() -> recordCategoryService.getSubCategories(parentRecordCategoryId))
+			assertThatThrownBy(() -> recordCategoryService.getCategories(parentRecordCategoryId))
 					.isInstanceOf(HaveParentRecordCategoryException.class);
 		}
 
@@ -73,7 +73,7 @@ class RecordCategoryServiceTest {
 					.willReturn(List.of(subRecordCategory1, subRecordCategory2));
 
 			// when
-			List<RecordCategoryResponseDto> subCategories = recordCategoryService.getSubCategories(
+			List<RecordCategoryResponseDto> subCategories = recordCategoryService.getCategories(
 					parentRecordCategoryId
 			);
 

--- a/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordCategoryServiceTest.java
@@ -31,41 +31,59 @@ class RecordCategoryServiceTest {
 	@Mock
 	private RecordCategoryRepository recordCategoryRepository;
 
-	@Test
-	@DisplayName("레코드 카테고리 전체 조회를 테스트한다")
-	void 레코드_카테고리_전체_조회를_테스트한다() {
-		// given
-		RecordCategory recordCategory1 = mock(RecordCategory.class);
-		RecordCategory recordCategory2 = mock(RecordCategory.class);
-		RecordCategory recordCategory3 = mock(RecordCategory.class);
+	@Nested
+	@DisplayName("레코드 카테고리를 조회할 때")
+	class 레코드_카테고리를_조회할_때 {
 
-		given(recordCategory1.getId())
-				.willReturn(1L);
-		given(recordCategory1.getName())
-				.willReturn("recordCategory1");
+		@Test
+		@DisplayName("상위가 아닌 서브 카테고리를 통해 조회하는 경우 예외를 던진다")
+		void 상위가_아닌_서브_카테고리를_통해_조회하는_경우_예외를_던진다() {
+			// given
+			Long parentRecordCategoryId = 3L;
+			RecordCategory parentRecordCategory = mock(RecordCategory.class);
+			RecordCategory grandParentRecordCategory = mock(RecordCategory.class);
 
-		given(recordCategory2.getId())
-				.willReturn(2L);
-		given(recordCategory2.getName())
-				.willReturn("recordCategory2");
-		given(recordCategory2.getParentRecordCategory())
-				.willReturn(recordCategory1);
+			given(recordCategoryRepository.findById(anyLong()))
+					.willReturn(Optional.of(parentRecordCategory));
+			given(parentRecordCategory.getParentRecordCategory())
+					.willReturn(grandParentRecordCategory);
 
-		given(recordCategory3.getId())
-				.willReturn(3L);
-		given(recordCategory3.getName())
-				.willReturn("recordCategory3");
+			// when, then
+			assertThatThrownBy(() -> recordCategoryService.getSubCategories(parentRecordCategoryId))
+					.isInstanceOf(HaveParentRecordCategoryException.class);
+		}
 
-		given(recordCategoryRepository.findAllFetchDepthIsOne())
-				.willReturn(List.of(recordCategory1, recordCategory2, recordCategory3));
-		// when
-		List<RecordCategoryResponseDto> result = recordCategoryService.getAllRecordCategories();
+		@Test
+		@DisplayName("정상적으로 조회 될 경우 예외를 던지지 않는다")
+		void 정상적으로_조회_될_경우_예외를_던지지_않는다() {
+			// given
+			Long parentRecordCategoryId = null;
+			RecordCategory subRecordCategory1 = mock(RecordCategory.class);
+			RecordCategory subRecordCategory2 = mock(RecordCategory.class);
 
-		// then
-		assertThat(result.size()).isEqualTo(2);
-		assertThat(result.get(0).getSubcategories().size()).isEqualTo(1);
-		assertThat(result.get(0).getSubcategories().get(0).getId()).isEqualTo(2L);
-		assertThat(result.get(1).getId()).isEqualTo(3L);
+			given(subRecordCategory1.getId())
+					.willReturn(1L);
+			given(subRecordCategory1.getName())
+					.willReturn("하위 카테고리1");
+			given(subRecordCategory2.getId())
+					.willReturn(2L);
+			given(subRecordCategory2.getName())
+					.willReturn("하위 카테고리2");
+			given(recordCategoryRepository.findAllByParentRecordCategory(null))
+					.willReturn(List.of(subRecordCategory1, subRecordCategory2));
+
+			// when
+			List<RecordCategoryResponseDto> subCategories = recordCategoryService.getSubCategories(
+					parentRecordCategoryId
+			);
+
+			// then
+			assertThat(subCategories.size()).isEqualTo(2);
+			assertThat(subCategories.get(0).getId()).isEqualTo(1L);
+			assertThat(subCategories.get(0).getName()).isEqualTo("하위 카테고리1");
+			assertThat(subCategories.get(1).getId()).isEqualTo(2L);
+			assertThat(subCategories.get(1).getName()).isEqualTo("하위 카테고리2");
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
## 관련 이슈 번호

[BE-195 / 카테고리 조회 로직에서 부모 id를 통해 조회하도록 수정](https://recodeit.atlassian.net/browse/BE-195)

## 설명
- 전체 조회 관련 테스트 코드와 서비스 코드 삭제
- RecordCategoryController에 전체 조회 API를 부모를 통해 조회하도록 설명 변경
- 관련 DTO에 적용된 빌더를 지우고, 정적 팩토리 메소드로 변경
- 부모를 통해 하위 카테고리를 조회하는 기능 추가
    - 컨트롤러로 받는 인자(parentRecordCategoryId)가 null이라면 상위 카테고리를 조회하도록 함
    - 관련 테스트 코드 추가

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
