### PR TITLE
[BE-198] 검색으로 레코드를 조회하는 API 개발

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -206,9 +206,9 @@ public class RecordController {
 	public ResponseEntity<MixRecordResponseDto> getMixRecords() {
 		return ResponseEntity.ok().body(recordService.getMixRecords());
 	}
-  
-  @ApiOperation(
-  		value = "최신 레코드 조회",
+
+	@ApiOperation(
+			value = "최신 레코드 조회",
 			notes = "최신의 레코드를 조회합니다."
 	)
 	@ApiResponses({
@@ -241,7 +241,7 @@ public class RecordController {
 	@GetMapping("/search")
 	public ResponseEntity<RecordBySearchResponseDto> getRecordsBySearch(
 			@ModelAttribute @Valid RecordBySearchRequestDto recordBySearchRequestDto
-  ) {
+	) {
 		return ResponseEntity.ok().body(recordService.getRecordsBySearch(recordBySearchRequestDto));
-  }
+	}
 }

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -23,6 +23,8 @@ import com.recordit.server.dto.record.RandomRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordByDateResponseDto;
+import com.recordit.server.dto.record.RecordBySearchRequestDto;
+import com.recordit.server.dto.record.RecordBySearchResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
@@ -200,5 +202,26 @@ public class RecordController {
 	@GetMapping("/mix")
 	public ResponseEntity<MixRecordResponseDto> getMixRecords() {
 		return ResponseEntity.ok().body(recordService.getMixRecords());
+	}
+
+	@ApiOperation(
+			value = "레코드를 검색으로 조회",
+			notes = "레코드를 검색으로 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "검색으로 레코드 조회 성공",
+					response = RandomRecordResponseDto.class
+			),
+			@ApiResponse(
+					code = 400,
+					message = "잘못 된 요청",
+					response = ErrorMessage.class
+			)
+	})
+	@GetMapping("/search")
+	public ResponseEntity<RecordBySearchResponseDto> getRecordsBySearch(
+			@ModelAttribute @Valid RecordBySearchRequestDto recordBySearchRequestDto) {
+		return ResponseEntity.ok().body(recordService.getRecordsBySearch(recordBySearchRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/RecordBySearchDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordBySearchDto.java
@@ -1,0 +1,54 @@
+package com.recordit.server.dto.record;
+
+import java.time.LocalDateTime;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordBySearchDto {
+	@ApiModelProperty(notes = "레코드의 카테고리 이름")
+	private String categoryName;
+
+	@ApiModelProperty(notes = "레코드 아이디")
+	private Long recordId;
+
+	@ApiModelProperty(notes = "레코드의 제목")
+	private String title;
+
+	@ApiModelProperty(notes = "레코드의 아이콘 이름")
+	private String iconName;
+
+	@ApiModelProperty(notes = "레코드의 색상 이름")
+	private String colorName;
+
+	@ApiModelProperty(notes = "레코드 작성 시각")
+	private LocalDateTime createdAt;
+
+	@ApiModelProperty(notes = "레코드에 달린 댓글 갯수")
+	private Long commentCount;
+
+	@Builder
+	public RecordBySearchDto(
+			Record record,
+			Long commentCount
+	) {
+		this.recordId = record.getId();
+		this.createdAt = record.getCreatedAt();
+		this.categoryName = record.getRecordCategory().getName();
+		this.title = record.getTitle();
+		this.commentCount = commentCount;
+		this.iconName = record.getRecordIcon().getName();
+		this.colorName = record.getRecordColor().getName();
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
@@ -1,0 +1,30 @@
+package com.recordit.server.dto.record;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiParam;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordBySearchRequestDto {
+	@ApiParam(value = "조회할 검색어", required = true, example = "레코드 제목")
+	@Pattern(regexp = "^.{1,12}$", message = "검색어 파라미터는 1글자 이상 12글자 이하입니다.")
+	private String searchKeyword;
+
+	@ApiParam(value = "조회할 페이지 번호 !주의: 0이상이어야 합니다.", required = true, example = "0")
+	@NotNull
+	@Min(0)
+	private Integer page;
+
+	@ApiParam(value = "조회할 레코드 갯수 !주의: 1이상이어야 합니다.", required = true, example = "1")
+	@NotNull
+	@Min(1)
+	private Integer size;
+}

--- a/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecordBySearchRequestDto {
 	@ApiParam(value = "조회할 검색어", required = true, example = "레코드 제목")
+	@NotNull
 	@Pattern(regexp = "^.{1,12}$", message = "검색어 파라미터는 1글자 이상 12글자 이하입니다.")
 	private String searchKeyword;
 

--- a/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordBySearchRequestDto.java
@@ -7,11 +7,13 @@ import javax.validation.constraints.Pattern;
 import io.swagger.annotations.ApiParam;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecordBySearchRequestDto {
 	@ApiParam(value = "조회할 검색어", required = true, example = "레코드 제목")

--- a/src/main/java/com/recordit/server/dto/record/RecordBySearchResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecordBySearchResponseDto.java
@@ -1,0 +1,48 @@
+package com.recordit.server.dto.record;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordBySearchResponseDto {
+	@ApiModelProperty(notes = "요청 레코드의 전체 페이지 개수", required = true)
+	private Integer totalPage;
+
+	@ApiModelProperty(notes = "요청 레코드의 전체 개수", required = true)
+	private Long totalCount;
+
+	@ApiModelProperty(notes = "레코드 리스트", required = true)
+	private List<RecordBySearchDto> recordBySearchDtos;
+
+	@Builder
+	public RecordBySearchResponseDto(
+			Page<Record> records,
+			Map<Record, Long> recordToNumOfComments
+	) {
+		this.totalPage = records.getTotalPages();
+		this.totalCount = records.getTotalElements();
+		this.recordBySearchDtos = records.stream()
+				.map(
+						record -> RecordBySearchDto.builder()
+								.record(record)
+								.commentCount(recordToNumOfComments.get(record))
+								.build()
+				).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import javax.validation.ConstraintViolationException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,6 +27,15 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorMessage> handleConstraintViolationException(
 			ConstraintViolationException exception) {
 		String message = exception.getConstraintViolations().iterator().next().getMessage();
+
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST, message));
+	}
+
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorMessage> handleBindException(
+			BindException exception) {
+		String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
 
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST, message));

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -62,4 +62,11 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			+ ") "
 			+ "order by RAND() limit :size", nativeQuery = true)
 	List<Record> findRandomRecordByRecordCategoryId(Integer size, Long categoryId);
+
+	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor"})
+	Page<Record> findByWriterAndTitleContaining(
+			Member writer,
+			String searchKeyword,
+			Pageable pageable
+	);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -63,7 +63,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			+ "order by RAND() limit :size", nativeQuery = true)
 	List<Record> findRandomRecordByRecordCategoryId(Integer size, Long categoryId);
 
-  @EntityGraph(attributePaths = {"recordIcon", "recordColor"})
+	@EntityGraph(attributePaths = {"recordIcon", "recordColor"})
 	@Query(value = "select r from RECORD r "
 			+ "where r.deletedAt is null")
 	Page<Record> findAllFetchRecordIconAndRecordColor(Pageable pageable);

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -332,7 +332,7 @@ public class RecordService {
 	}
 
 	@Transactional(readOnly = true)
-  public Page<RecentRecordResponseDto> getRecentRecord(
+	public Page<RecentRecordResponseDto> getRecentRecord(
 			RecentRecordRequestDto recentRecordRequestDto
 	) {
 		Page<Record> recordPage = recordRepository.findAllFetchRecordIconAndRecordColor(
@@ -350,7 +350,7 @@ public class RecordService {
 						commentRepository.countByRecordId(record.getId())
 				)
 		);
-  }
+	}
 
 	@Transactional(readOnly = true)
 	public RecordBySearchResponseDto getRecordsBySearch(

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -27,6 +27,8 @@ import com.recordit.server.dto.record.RandomRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordByDateResponseDto;
+import com.recordit.server.dto.record.RecordBySearchRequestDto;
+import com.recordit.server.dto.record.RecordBySearchResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
@@ -324,6 +326,42 @@ public class RecordService {
 
 		return MixRecordResponseDto.builder()
 				.mixRecordDto(randomCommentList)
+				.build();
+	}
+
+	@Transactional(readOnly = true)
+	public RecordBySearchResponseDto getRecordsBySearch(RecordBySearchRequestDto recordBySearchRequestDto) {
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
+
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+		PageRequest pageRequest = PageRequest.of(
+				recordBySearchRequestDto.getPage(),
+				recordBySearchRequestDto.getSize(),
+				Sort.by(Sort.Direction.DESC, "createdAt")
+		);
+
+		Page<Record> findRecords = recordRepository.findByWriterAndTitleContaining(
+				member,
+				recordBySearchRequestDto.getSearchKeyword(),
+				pageRequest
+		);
+
+		Map<Record, Long> recordToNumOfComment = new LinkedHashMap<>();
+		for (Record findRecord : findRecords) {
+			recordToNumOfComment.put(
+					// key
+					findRecord,
+					// value
+					commentRepository.countByRecordAndParentCommentIsNull(findRecord)
+			);
+		}
+
+		return RecordBySearchResponseDto.builder()
+				.records(findRecords)
+				.recordToNumOfComments(recordToNumOfComment)
 				.build();
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -565,8 +565,8 @@ class RecordServiceTest {
 					.doesNotThrowAnyException();
 		}
 	}
-  
-  @DisplayName("최신 레코드를 조회_할 때")
+
+	@DisplayName("최신 레코드를 조회_할 때")
 	class 최신_레코드를_조회_할_때 {
 		RecentRecordRequestDto recentRecordRequestDto = RecentRecordRequestDto.builder()
 				.page(0)
@@ -684,5 +684,6 @@ class RecordServiceTest {
 			// when, then
 			assertThatCode(() -> recordService.getRecordsBySearch(recordBySearchRequestDto))
 					.doesNotThrowAnyException();
+		}
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -565,7 +565,8 @@ class RecordServiceTest {
 					.doesNotThrowAnyException();
 		}
 	}
-
+	
+	@Nested
 	@DisplayName("최신 레코드를 조회_할 때")
 	class 최신_레코드를_조회_할_때 {
 		RecentRecordRequestDto recentRecordRequestDto = RecentRecordRequestDto.builder()

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -27,6 +27,7 @@ import com.recordit.server.domain.RecordIcon;
 import com.recordit.server.dto.record.ModifyRecordRequestDto;
 import com.recordit.server.dto.record.RandomRecordRequestDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
+import com.recordit.server.dto.record.RecordBySearchRequestDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.exception.member.MemberNotFoundException;
@@ -554,6 +555,25 @@ class RecordServiceTest {
 			//when, then
 			assertThatCode(() -> recordService.getMixRecords())
 					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("검색으로 레코드를 조회할 때")
+	class 검색으로_레코드를_조회할_때 {
+		@Test
+		@DisplayName("회원_정보를_찾을 수 없다면 예외를 던진다")
+		void 회원_정보를_찾을_수_없다면_예외를_던진다() {
+			// given
+			RecordBySearchRequestDto recordBySearchRequestDto = mock(RecordBySearchRequestDto.class);
+
+			given(memberRepository.findById(anyLong()))
+					.willReturn(Optional.empty());
+
+			// when, then
+			assertThatThrownBy(() -> recordService.getRecordsBySearch(recordBySearchRequestDto))
+					.isInstanceOf(MemberNotFoundException.class)
+					.hasMessage("회원 정보를 찾을 수 없습니다.");
 		}
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -565,7 +565,7 @@ class RecordServiceTest {
 					.doesNotThrowAnyException();
 		}
 	}
-	
+
 	@Nested
 	@DisplayName("최신 레코드를 조회_할 때")
 	class 최신_레코드를_조회_할_때 {


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-198 /검색으로 레코드를 조회하는 API 개발 ](https://recodeit.atlassian.net/browse/BE-198)
## 설명
- 검색으로 레코드를 조회하는 API를 개발하였습니다.
- 달력으로 레코드를 조회하는 API는 기존에 개발된 API(마이레코드 조회)를 재사용할 수 있으므로 이번 스프린트에서 따로 개발하지 않았습니다.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] 테스트코드 작성
- [x] RecordBySearchRequestDto의 searchKeyword필드 NotNull 유효성 검사 추가
- [x] 정상적인 경우의 테스트코드 추가
## 질문사항
