### PR TITLE
[BE-205] 랜덤 레코드 조회 시 카테고리 조회 휴면에러 수정

### DIFF
--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -282,7 +282,7 @@ public class RecordService {
 	public List<RandomRecordResponseDto> getRandomRecord(
 			RandomRecordRequestDto randomRecordRequestDto
 	) {
-		if (!recordRepository.existsById(randomRecordRequestDto.getRecordCategoryId())) {
+		if (!recordCategoryRepository.existsById(randomRecordRequestDto.getRecordCategoryId())) {
 			throw new RecordCategoryNotFoundException("카테고리 정보를 찾을 수 없습니다.");
 		}
 

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -515,7 +515,7 @@ class RecordServiceTest {
 		@DisplayName("정상적이라면 예외를 던지지 않는다")
 		void 정상적이라면_예외를_던지지_않는다() {
 			// given
-			given(recordRepository.existsById(anyLong()))
+			given(recordCategoryRepository.existsById(anyLong()))
 					.willReturn(true);
 			given(recordRepository.findRandomRecordByRecordCategoryId(any(), anyLong()))
 					.willReturn(new ArrayList<>());


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-205 / 랜덤 레코드 조회 시 카테고리 조회 휴면에러 수정](https://recodeit.atlassian.net/browse/이슈번호)

## 설명
랜덤 레코드 조회 시 카테고리 정보를 가져오는 로직에서 레코드를 가져오도록 작성된 코드가 있어 hotfix로 master로 PR올립니다

## 변경사항
- [x] 랜덤 레코드 조회 테스트코드 수정
- [x] 랜덤 레코드 조회 시 카테고리를 정상적으로 조회하도록 수정

## 질문사항
