### PR TITLE
[BE-208] 추억레코드 응답 값 중 iconColor를 colorName으로 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordDto.java
@@ -27,8 +27,8 @@ public class MemoryRecordDto {
 	@ApiModelProperty(notes = "추억 레코드 아이콘 이름")
 	private String iconName;
 
-	@ApiModelProperty(notes = "추억 레코드 아이콘 색상")
-	private String iconColor;
+	@ApiModelProperty(notes = "추억 레코드 컬러 이름")
+	private String colorName;
 
 	@ApiModelProperty(notes = "추억 레코드 댓글 리스트")
 	private List<MemoryRecordCommentDto> memoryRecordComments;
@@ -38,13 +38,13 @@ public class MemoryRecordDto {
 			Long recordId,
 			String title,
 			String iconName,
-			String iconColor,
+			String colorName,
 			List<Comment> memoryRecordComments
 	) {
 		this.recordId = recordId;
 		this.title = title;
 		this.iconName = iconName;
-		this.iconColor = iconColor;
+		this.colorName = colorName;
 		this.memoryRecordComments = memoryRecordComments.stream()
 				.map(
 						comment -> MemoryRecordCommentDto.builder()

--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordResponseDto.java
@@ -44,7 +44,7 @@ public class MemoryRecordResponseDto {
 						record -> MemoryRecordDto.builder()
 								.recordId(record.getId())
 								.title(record.getTitle())
-								.iconColor(record.getRecordColor().getName())
+								.colorName(record.getRecordColor().getName())
 								.iconName(record.getRecordIcon().getName())
 								.memoryRecordComments(recordToComments.get(record))
 								.build()


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-208 / 추억레코드 응답 값 중 iconColor를 colorName으로 변경](https://recodeit.atlassian.net/browse/BE-208)

## 설명
추억레코드 리스트 응답 값 멤버필드 이름이 iconColor로 되어있는 부분이 있어
프론트 측 수정요청에 따라 colorName으로 수정하였습니다.

merge시 프론트 분들에게 꼭 알려주세요. 해당 부분 때문에 프론트에서 에러 발생 가능성 있습니다.

## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
