### PR TITLE
[BE-209] 최신 레코드 조회 시 requestDto에 시간 값 추가

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -220,6 +220,7 @@ public class RecordController {
 	public ResponseEntity<Page<RecentRecordResponseDto>> getRecentRecord(
 			@ModelAttribute @Valid RecentRecordRequestDto recentRecordRequestDto
 	) {
+		System.out.println("recentRecordRequestDto.getDateTime() = " + recentRecordRequestDto.getDateTime());
 		return ResponseEntity.ok(recordService.getRecentRecord(recentRecordRequestDto));
 	}
 

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -220,7 +220,6 @@ public class RecordController {
 	public ResponseEntity<Page<RecentRecordResponseDto>> getRecentRecord(
 			@ModelAttribute @Valid RecentRecordRequestDto recentRecordRequestDto
 	) {
-		System.out.println("recentRecordRequestDto.getDateTime() = " + recentRecordRequestDto.getDateTime());
 		return ResponseEntity.ok(recordService.getRecentRecord(recentRecordRequestDto));
 	}
 

--- a/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
@@ -1,7 +1,11 @@
 package com.recordit.server.dto.record;
 
+import java.time.LocalDateTime;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiParam;
@@ -17,6 +21,9 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class RecentRecordRequestDto {
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+	private LocalDateTime dateTime;
 
 	@ApiParam(value = "페이지 번호", required = true, example = "0")
 	@NotNull

--- a/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/RecentRecordRequestDto.java
@@ -22,6 +22,8 @@ import lombok.ToString;
 @Builder
 public class RecentRecordRequestDto {
 
+	@ApiParam(value = "기준 날짜", required = true, example = "yyy-MM-dd HH:mm")
+	@NotNull
 	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
 	private LocalDateTime dateTime;
 

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -65,8 +65,8 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
 	@EntityGraph(attributePaths = {"recordIcon", "recordColor"})
 	@Query(value = "select r from RECORD r "
-			+ "where r.deletedAt is null")
-	Page<Record> findAllFetchRecordIconAndRecordColor(Pageable pageable);
+			+ "where r.deletedAt is null and r.createdAt <= :dateTime")
+	Page<Record> findAllByCreatedAtBeforeFetchRecordIconAndRecordColor(Pageable pageable, LocalDateTime dateTime);
 
 	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor"})
 	Page<Record> findByWriterAndTitleContaining(

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -335,13 +335,14 @@ public class RecordService {
 	public Page<RecentRecordResponseDto> getRecentRecord(
 			RecentRecordRequestDto recentRecordRequestDto
 	) {
-		Page<Record> recordPage = recordRepository.findAllFetchRecordIconAndRecordColor(
+		Page<Record> recordPage = recordRepository.findAllByCreatedAtBeforeFetchRecordIconAndRecordColor(
 				PageRequest.of(
 						recentRecordRequestDto.getPage(),
 						recentRecordRequestDto.getSize(),
 						Sort.Direction.DESC,
 						"createdAt"
-				)
+				),
+				recentRecordRequestDto.getDateTime()
 		);
 
 		return recordPage.map(

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -570,6 +571,7 @@ class RecordServiceTest {
 	@DisplayName("최신 레코드를 조회_할 때")
 	class 최신_레코드를_조회_할_때 {
 		RecentRecordRequestDto recentRecordRequestDto = RecentRecordRequestDto.builder()
+				.dateTime(LocalDateTime.now())
 				.page(0)
 				.size(10)
 				.build();
@@ -585,8 +587,10 @@ class RecordServiceTest {
 					"createdAt"
 			);
 
-			given(recordRepository.findAllFetchRecordIconAndRecordColor(pageRequest))
-					.willReturn(new PageImpl<>(List.of(), pageRequest, 0));
+			given(recordRepository.findAllByCreatedAtBeforeFetchRecordIconAndRecordColor(
+					pageRequest, recentRecordRequestDto.getDateTime())
+			).willReturn(new PageImpl<>(List.of(), pageRequest, 0));
+
 			//when
 			Page<RecentRecordResponseDto> recentRecord = recordService.getRecentRecord(
 					recentRecordRequestDto);
@@ -618,8 +622,10 @@ class RecordServiceTest {
 					.willReturn("color");
 			given(mockRecordIcon.getName())
 					.willReturn("icon");
-			given(recordRepository.findAllFetchRecordIconAndRecordColor(pageRequest))
-					.willReturn(new PageImpl<>(recordList, pageRequest, 1));
+			given(recordRepository.findAllByCreatedAtBeforeFetchRecordIconAndRecordColor(
+					pageRequest, recentRecordRequestDto.getDateTime())
+			).willReturn(new PageImpl<>(recordList, pageRequest, 1));
+
 			//when
 			Page<RecentRecordResponseDto> recentRecord = recordService.getRecentRecord(
 					recentRecordRequestDto


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-209 / 최신 레코드 조회 시 requestDto에 시간 값 추가](https://recodeit.atlassian.net/browse/BE-209)

## 설명
시간 기준으로 이전에 작성된 최신 레코드만 조회하도록 requestDto input에 시간 값 추가 하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
