### PR TITLE
[BE-201] 레코드 쓴 날짜 반환

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -1,6 +1,7 @@
 package com.recordit.server.controller;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.Valid;
 
@@ -31,6 +32,7 @@ import com.recordit.server.dto.record.RecordBySearchResponseDto;
 import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
+import com.recordit.server.dto.record.WrittenRecordDayRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.mix.MixRecordResponseDto;
@@ -243,5 +245,12 @@ public class RecordController {
 			@ModelAttribute @Valid RecordBySearchRequestDto recordBySearchRequestDto
 	) {
 		return ResponseEntity.ok().body(recordService.getRecordsBySearch(recordBySearchRequestDto));
+	}
+
+	@GetMapping("/days")
+	public ResponseEntity<Set<Integer>> getWrittenRecordDays(
+			@Valid WrittenRecordDayRequestDto writtenRecordDayRequestDto
+	) {
+		return ResponseEntity.ok(recordService.getWrittenRecordDays(writtenRecordDayRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -1,7 +1,6 @@
 package com.recordit.server.controller;
 
 import java.util.List;
-import java.util.Set;
 
 import javax.validation.Valid;
 
@@ -33,6 +32,7 @@ import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.dto.record.WrittenRecordDayRequestDto;
+import com.recordit.server.dto.record.WrittenRecordDayResponseDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.mix.MixRecordResponseDto;
@@ -248,7 +248,7 @@ public class RecordController {
 	}
 
 	@GetMapping("/days")
-	public ResponseEntity<Set<Integer>> getWrittenRecordDays(
+	public ResponseEntity<WrittenRecordDayResponseDto> getWrittenRecordDays(
 			@Valid WrittenRecordDayRequestDto writtenRecordDayRequestDto
 	) {
 		return ResponseEntity.ok(recordService.getWrittenRecordDays(writtenRecordDayRequestDto));

--- a/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
@@ -1,0 +1,27 @@
+package com.recordit.server.dto.record;
+
+import java.time.YearMonth;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class WrittenRecordDayRequestDto {
+
+	@NotNull
+	@DateTimeFormat(pattern = "yyyy-MM")
+	private YearMonth yearMonth;
+}
+

--- a/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
@@ -1,6 +1,6 @@
 package com.recordit.server.dto.record;
 
-import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 import javax.validation.constraints.NotNull;
 
@@ -20,8 +20,8 @@ import lombok.ToString;
 @Builder
 public class WrittenRecordDayRequestDto {
 
-	@NotNull
+	@NotNull(message = "날짜를 입력해주세요.")
 	@DateTimeFormat(pattern = "yyyy-MM")
-	private LocalDateTime dateTime;
+	private YearMonth yearMonth;
 }
 

--- a/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WrittenRecordDayRequestDto.java
@@ -1,6 +1,6 @@
 package com.recordit.server.dto.record;
 
-import java.time.YearMonth;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 
@@ -22,6 +22,6 @@ public class WrittenRecordDayRequestDto {
 
 	@NotNull
 	@DateTimeFormat(pattern = "yyyy-MM")
-	private YearMonth yearMonth;
+	private LocalDateTime dateTime;
 }
 

--- a/src/main/java/com/recordit/server/dto/record/WrittenRecordDayResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/WrittenRecordDayResponseDto.java
@@ -1,0 +1,24 @@
+package com.recordit.server.dto.record;
+
+import java.util.Set;
+
+import io.swagger.annotations.ApiParam;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class WrittenRecordDayResponseDto {
+	@ApiParam(value = "내가 쓴 레코드 일자 목록", required = true)
+	private Set<Integer> WrittenRecordDayDto;
+
+	private WrittenRecordDayResponseDto(Set<Integer> WrittenRecordDayDto) {
+		this.WrittenRecordDayDto = WrittenRecordDayDto;
+	}
+
+	public static WrittenRecordDayResponseDto of(Set<Integer> WrittenRecordDayDto) {
+		return new WrittenRecordDayResponseDto(WrittenRecordDayDto);
+	}
+}

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -74,4 +74,10 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			String searchKeyword,
 			Pageable pageable
 	);
+
+	List<Record> findAllByWriterAndCreatedAtBetween(
+			Member writer,
+			LocalDateTime startTime,
+			LocalDateTime endTime
+	);
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -400,7 +400,6 @@ public class RecordService {
 	public Set<Integer> getWrittenRecordDays(
 			WrittenRecordDayRequestDto writtenRecordDayRequestDto
 	) {
-		sessionUtil.saveUserIdInSession(1L);
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
 

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -406,8 +406,8 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getDateTime());
-		LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getDateTime());
+		LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
+		LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
 
 		TreeSet<Integer> writtenRecordDays =
 				recordRepository.findAllByWriterAndCreatedAtBetween(member, start, end)

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -40,6 +39,7 @@ import com.recordit.server.dto.record.RecordDetailResponseDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.dto.record.WrittenRecordDayRequestDto;
+import com.recordit.server.dto.record.WrittenRecordDayResponseDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.mix.MixRecordDto;
@@ -397,7 +397,7 @@ public class RecordService {
 				.build();
 	}
 
-	public Set<Integer> getWrittenRecordDays(
+	public WrittenRecordDayResponseDto getWrittenRecordDays(
 			WrittenRecordDayRequestDto writtenRecordDayRequestDto
 	) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
@@ -406,14 +406,15 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
-		LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
+		LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getDateTime());
+		LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getDateTime());
 
 		TreeSet<Integer> writtenRecordDays =
 				recordRepository.findAllByWriterAndCreatedAtBetween(member, start, end)
 						.stream()
 						.map(record -> record.getCreatedAt().getDayOfMonth())
 						.collect(Collectors.toCollection(TreeSet::new));
-		return writtenRecordDays;
+
+		return WrittenRecordDayResponseDto.of(writtenRecordDays);
 	}
 }

--- a/src/main/java/com/recordit/server/util/DateTimeUtil.java
+++ b/src/main/java/com/recordit/server/util/DateTimeUtil.java
@@ -3,7 +3,6 @@ package com.recordit.server.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.YearMonth;
 
 public class DateTimeUtil {
 
@@ -19,21 +18,11 @@ public class DateTimeUtil {
 		return LocalDateTime.of(localDate, LocalTime.MAX);
 	}
 
-	public static LocalDateTime getFirstDayOfMonth(YearMonth yearMonth) {
-		LocalDate standardDate = getStandardDate(yearMonth);
-		return getStartOfDay(standardDate.withDayOfMonth(1));
+	public static LocalDateTime getFirstDayOfMonth(LocalDateTime dateTime) {
+		return getStartOfDay(dateTime.withDayOfMonth(1).toLocalDate());
 	}
 
-	public static LocalDateTime getLastDayOfMonth(YearMonth yearMonth) {
-		LocalDate standardDate = getStandardDate(yearMonth);
-		return getEndOfDay(standardDate.withDayOfMonth(standardDate.lengthOfMonth()));
-	}
-
-	private static LocalDate getStandardDate(YearMonth yearMonth) {
-		return LocalDate.of(
-				yearMonth.getYear(),
-				yearMonth.getMonth(),
-				1
-		);
+	public static LocalDateTime getLastDayOfMonth(LocalDateTime dateTime) {
+		return getEndOfDay(dateTime.withDayOfMonth(dateTime.toLocalDate().lengthOfMonth()).toLocalDate());
 	}
 }

--- a/src/main/java/com/recordit/server/util/DateTimeUtil.java
+++ b/src/main/java/com/recordit/server/util/DateTimeUtil.java
@@ -3,6 +3,7 @@ package com.recordit.server.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 
 public class DateTimeUtil {
 
@@ -18,11 +19,21 @@ public class DateTimeUtil {
 		return LocalDateTime.of(localDate, LocalTime.MAX);
 	}
 
-	public static LocalDateTime getFirstDayOfMonth(LocalDateTime dateTime) {
-		return getStartOfDay(dateTime.withDayOfMonth(1).toLocalDate());
+	public static LocalDateTime getFirstDayOfMonth(YearMonth yearMonth) {
+		LocalDate standardDate = getStandardDate(yearMonth);
+		return getStartOfDay(standardDate.withDayOfMonth(1));
 	}
 
-	public static LocalDateTime getLastDayOfMonth(LocalDateTime dateTime) {
-		return getEndOfDay(dateTime.withDayOfMonth(dateTime.toLocalDate().lengthOfMonth()).toLocalDate());
+	public static LocalDateTime getLastDayOfMonth(YearMonth yearMonth) {
+		LocalDate standardDate = getStandardDate(yearMonth);
+		return getEndOfDay(standardDate.withDayOfMonth(standardDate.lengthOfMonth()));
+	}
+
+	private static LocalDate getStandardDate(YearMonth yearMonth) {
+		return LocalDate.of(
+				yearMonth.getYear(),
+				yearMonth.getMonth(),
+				1
+		);
 	}
 }

--- a/src/main/java/com/recordit/server/util/DateTimeUtil.java
+++ b/src/main/java/com/recordit/server/util/DateTimeUtil.java
@@ -3,6 +3,7 @@ package com.recordit.server.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 
 public class DateTimeUtil {
 
@@ -16,5 +17,23 @@ public class DateTimeUtil {
 
 	public static LocalDateTime getEndOfDay(LocalDate localDate) {
 		return LocalDateTime.of(localDate, LocalTime.MAX);
+	}
+
+	public static LocalDateTime getFirstDayOfMonth(YearMonth yearMonth) {
+		LocalDate standardDate = getStandardDate(yearMonth);
+		return getStartOfDay(standardDate.withDayOfMonth(1));
+	}
+
+	public static LocalDateTime getLastDayOfMonth(YearMonth yearMonth) {
+		LocalDate standardDate = getStandardDate(yearMonth);
+		return getEndOfDay(standardDate.withDayOfMonth(standardDate.lengthOfMonth()));
+	}
+
+	private static LocalDate getStandardDate(YearMonth yearMonth) {
+		return LocalDate.of(
+				yearMonth.getYear(),
+				yearMonth.getMonth(),
+				1
+		);
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -6,13 +6,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
-import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,6 +40,7 @@ import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordBySearchRequestDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
 import com.recordit.server.dto.record.WrittenRecordDayRequestDto;
+import com.recordit.server.dto.record.WrittenRecordDayResponseDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.record.FixRecordNotExistException;
@@ -702,7 +701,7 @@ class RecordServiceTest {
 	@DisplayName("작성된 레코드의 일자를 리스트로 조회할 때")
 	class 작성된_레코드의_일자를_리스트로_조회할_때 {
 		WrittenRecordDayRequestDto writtenRecordDayRequestDto = WrittenRecordDayRequestDto.builder()
-				.yearMonth(YearMonth.of(2023, 01))
+				.dateTime(LocalDateTime.now())
 				.build();
 
 		@Test
@@ -725,8 +724,8 @@ class RecordServiceTest {
 			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 
-			LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
-			LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
+			LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getDateTime());
+			LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getDateTime());
 
 			given(recordRepository.findAllByWriterAndCreatedAtBetween(mockMember, start, end))
 					.willReturn(List.of(mockRecord));
@@ -736,12 +735,13 @@ class RecordServiceTest {
 					.willReturn(2);
 
 			// when
-			Set<Integer> days = recordService.getWrittenRecordDays(writtenRecordDayRequestDto);
+			WrittenRecordDayResponseDto writtenRecordDays = recordService.getWrittenRecordDays(
+					writtenRecordDayRequestDto);
 
 			// then
 			assertThatCode(() -> recordService.getWrittenRecordDays(writtenRecordDayRequestDto))
 					.doesNotThrowAnyException();
-			assertThat(days.contains(2)).isTrue();
+			assertThat(writtenRecordDays.getWrittenRecordDayDto().contains(2)).isTrue();
 		}
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -1,14 +1,19 @@
 package com.recordit.server.service;
 
+import static com.recordit.server.util.DateTimeUtil.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,6 +42,7 @@ import com.recordit.server.dto.record.RecentRecordResponseDto;
 import com.recordit.server.dto.record.RecordByDateRequestDto;
 import com.recordit.server.dto.record.RecordBySearchRequestDto;
 import com.recordit.server.dto.record.WriteRecordRequestDto;
+import com.recordit.server.dto.record.WrittenRecordDayRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.exception.member.MemberNotFoundException;
 import com.recordit.server.exception.record.FixRecordNotExistException;
@@ -685,6 +691,59 @@ class RecordServiceTest {
 			// when, then
 			assertThatCode(() -> recordService.getRecordsBySearch(recordBySearchRequestDto))
 					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("작성된 레코드의 일자를 리스트로 조회할 때")
+	class 작성된_레코드의_일자를_리스트로_조회할_때 {
+		WrittenRecordDayRequestDto writtenRecordDayRequestDto = WrittenRecordDayRequestDto.builder()
+				.yearMonth(YearMonth.of(2023, 01))
+				.build();
+
+		@Test
+		@DisplayName("회원_정보를_찾을 수 없다면 예외를 던진다")
+		void 회원_정보를_찾을_수_없다면_예외를_던진다() {
+			// given
+			given(memberRepository.findById(anyLong()))
+					.willReturn(Optional.empty());
+
+			// when, then
+			assertThatThrownBy(() -> recordService.getWrittenRecordDays(writtenRecordDayRequestDto))
+					.isInstanceOf(MemberNotFoundException.class)
+					.hasMessage("회원 정보를 찾을 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("정상적이라면 예외를 던지지 않는다")
+		void 정상적이라면_예외를_던지지_않는다() {
+			// given
+			given(memberRepository.findById(anyLong()))
+					.willReturn(Optional.of(mockMember));
+
+			LocalDate standardDate = LocalDate.of(
+					writtenRecordDayRequestDto.getYearMonth().getYear(),
+					writtenRecordDayRequestDto.getYearMonth().getMonth(),
+					1
+			);
+
+			LocalDateTime start = getStartOfDay(standardDate.withDayOfMonth(1));
+			LocalDateTime end = getEndOfDay(standardDate.withDayOfMonth(standardDate.lengthOfMonth()));
+
+			given(recordRepository.findAllByWriterAndCreatedAtBetween(mockMember, start, end))
+					.willReturn(List.of(mockRecord));
+			given(mockRecord.getCreatedAt())
+					.willReturn(mock(LocalDateTime.class));
+			given(mockRecord.getCreatedAt().getDayOfMonth())
+					.willReturn(2);
+
+			// when
+			Set<Integer> days = recordService.getWrittenRecordDays(writtenRecordDayRequestDto);
+
+			// then
+			assertThatCode(() -> recordService.getWrittenRecordDays(writtenRecordDayRequestDto))
+					.doesNotThrowAnyException();
+			assertThat(days.contains(2)).isTrue();
 		}
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -721,14 +720,8 @@ class RecordServiceTest {
 			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 
-			LocalDate standardDate = LocalDate.of(
-					writtenRecordDayRequestDto.getYearMonth().getYear(),
-					writtenRecordDayRequestDto.getYearMonth().getMonth(),
-					1
-			);
-
-			LocalDateTime start = getStartOfDay(standardDate.withDayOfMonth(1));
-			LocalDateTime end = getEndOfDay(standardDate.withDayOfMonth(standardDate.lengthOfMonth()));
+			LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
+			LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
 
 			given(recordRepository.findAllByWriterAndCreatedAtBetween(mockMember, start, end))
 					.willReturn(List.of(mockRecord));

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -701,7 +702,7 @@ class RecordServiceTest {
 	@DisplayName("작성된 레코드의 일자를 리스트로 조회할 때")
 	class 작성된_레코드의_일자를_리스트로_조회할_때 {
 		WrittenRecordDayRequestDto writtenRecordDayRequestDto = WrittenRecordDayRequestDto.builder()
-				.dateTime(LocalDateTime.now())
+				.yearMonth(YearMonth.of(2023, 01))
 				.build();
 
 		@Test
@@ -724,8 +725,8 @@ class RecordServiceTest {
 			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 
-			LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getDateTime());
-			LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getDateTime());
+			LocalDateTime start = getFirstDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
+			LocalDateTime end = getLastDayOfMonth(writtenRecordDayRequestDto.getYearMonth());
 
 			given(recordRepository.findAllByWriterAndCreatedAtBetween(mockMember, start, end))
 					.willReturn(List.of(mockRecord));


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-201 / 레코드 쓴 날짜 반환](https://recodeit.atlassian.net/browse/BE-201)

## 설명
달력 버튼을 클릭 했을 때 로그인 된 사용자의 레코드 쓴 날짜를 반환해주는 API 입니다.
입력받은 년도와 월의 1일 부터 ~ 입력받은 년도와 월의 마지막일까지 between으로 처리하였습니다

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
