### PR TITLE
[BE-210] 회원의 닉네임을 변경하는 API 개발

### DIFF
--- a/src/main/java/com/recordit/server/controller/MemberController.java
+++ b/src/main/java/com/recordit/server/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.recordit.server.constant.LoginType;
 import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.ModifyMemberRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
@@ -132,4 +134,16 @@ public class MemberController {
 		return ResponseEntity.status(HttpStatus.OK).body(memberService.findNicknameIfPresent());
 	}
 
+	@ApiOperation(
+			value = "회원 닉네임 변경",
+			notes = "회원 닉네임을 변경합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "변경된 회원의 PK값 반환", response = Long.class),
+			@ApiResponse(code = 400, message = "세션에 사용자 정보가 저장되어 있지 않을 때")
+	})
+	@PutMapping
+	public ResponseEntity<Long> modifyMember(@RequestBody @Valid ModifyMemberRequestDto modifyMemberRequestDto) {
+		return ResponseEntity.status(HttpStatus.OK).body(memberService.modifyMember(modifyMemberRequestDto));
+	}
 }

--- a/src/main/java/com/recordit/server/domain/Member.java
+++ b/src/main/java/com/recordit/server/domain/Member.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import com.recordit.server.constant.LoginType;
+import com.recordit.server.dto.member.ModifyMemberRequestDto;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -55,5 +56,10 @@ public class Member extends BaseEntity {
 
 	public static Member of(String username, String password, String nickname, String oauthId, LoginType loginType) {
 		return new Member(username, password, nickname, oauthId, loginType);
+	}
+
+	public Long modify(final ModifyMemberRequestDto modifyMemberRequestDto) {
+		this.nickname = modifyMemberRequestDto.getNickName();
+		return this.id;
 	}
 }

--- a/src/main/java/com/recordit/server/dto/member/ModifyMemberRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/ModifyMemberRequestDto.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -19,4 +20,9 @@ public class ModifyMemberRequestDto {
 	@NotBlank(message = "변경할 닉네임은 빈값일 수 없습니다.")
 	@Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,8}$", message = "닉네임은 국문,영문,숫자를 포함한 2글자이상 8글자 이하입니다.")
 	private String nickName;
+
+	@Builder
+	public ModifyMemberRequestDto(String nickName) {
+		this.nickName = nickName;
+	}
 }

--- a/src/main/java/com/recordit/server/dto/member/ModifyMemberRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/member/ModifyMemberRequestDto.java
@@ -1,0 +1,22 @@
+package com.recordit.server.dto.member;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ModifyMemberRequestDto {
+	@ApiModelProperty(notes = "변경할 닉네임", required = true)
+	@NotBlank(message = "변경할 닉네임은 빈값일 수 없습니다.")
+	@Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,8}$", message = "닉네임은 국문,영문,숫자를 포함한 2글자이상 8글자 이하입니다.")
+	private String nickName;
+}

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.recordit.server.constant.LoginType;
 import com.recordit.server.domain.Member;
 import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.ModifyMemberRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
@@ -97,5 +98,15 @@ public class MemberService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 		return member.getNickname();
+	}
+
+	@Transactional
+	public Long modifyMember(ModifyMemberRequestDto modifyMemberRequestDto) {
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+		return member.modify(modifyMemberRequestDto);
 	}
 }

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.recordit.server.constant.LoginType;
 import com.recordit.server.domain.Member;
 import com.recordit.server.dto.member.LoginRequestDto;
+import com.recordit.server.dto.member.ModifyMemberRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
 import com.recordit.server.dto.member.RegisterSessionResponseDto;
 import com.recordit.server.exception.member.DuplicateNicknameException;
@@ -260,6 +261,47 @@ public class MemberServiceTest {
 
 			// when, then
 			assertThatCode(() -> memberService.findNicknameIfPresent())
+					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("회원정보_변경_에서")
+	class 회원정보_변경_에서 {
+		private Long memberId = 1L;
+
+		private ModifyMemberRequestDto modifyMemberRequestDto = ModifyMemberRequestDto.builder()
+				.nickName("변경된 닉네임")
+				.build();
+
+		@Test
+		@DisplayName("회원_정보를_찾을 수 없다면 예외를 던진다")
+		void 회원_정보를_찾을_수_없다면_예외를_던진다() {
+			// given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(memberId);
+
+			given(memberRepository.findById(memberId))
+					.willReturn(Optional.empty());
+
+			// when, then
+			assertThatThrownBy(() -> memberService.modifyMember(modifyMemberRequestDto))
+					.isInstanceOf(MemberNotFoundException.class)
+					.hasMessage("회원 정보를 찾을 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("정상적이라면 예외를 던지지 않는다")
+		void 정상적이라면_예외를_던지지_않는다() {
+			//given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(memberId);
+
+			given(memberRepository.findById(memberId))
+					.willReturn(Optional.of(mockMember));
+
+			//when, then
+			assertThatCode(() -> memberService.modifyMember(modifyMemberRequestDto))
 					.doesNotThrowAnyException();
 		}
 	}


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-210/회원의 닉네임을 변경하는 API 개발](https://recodeit.atlassian.net/browse/BE-210)
## 설명
회원의 닉네임을 변경하는 API를 개발하였습니다.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x]  회원의 닉네임을 변경하는 API의 테스트코드를 작성하였습니다.

## 질문사항
