### PR TITLE
[BE-200] 랭킹 시스템 구현

### DIFF
--- a/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
+++ b/src/main/java/com/recordit/server/configuration/WebMvcConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.recordit.server.converter.LoginTypeConverter;
+import com.recordit.server.converter.RankingPeriodConverter;
 
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
@@ -35,5 +36,6 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addFormatters(FormatterRegistry registry) {
 		registry.addConverter(new LoginTypeConverter());
+		registry.addConverter(new RankingPeriodConverter());
 	}
 }

--- a/src/main/java/com/recordit/server/constant/RankingPeriod.java
+++ b/src/main/java/com/recordit/server/constant/RankingPeriod.java
@@ -1,0 +1,19 @@
+package com.recordit.server.constant;
+
+import java.util.Arrays;
+
+import com.recordit.server.exception.record.NotMatchRankingPeriodException;
+
+public enum RankingPeriod {
+	DAY,
+	WEEK,
+	MONTH,
+	TOTAL;
+
+	public static RankingPeriod findByString(String str) {
+		return Arrays.stream(RankingPeriod.values())
+				.filter(rankingPeriod -> rankingPeriod.name().equals(str))
+				.findFirst()
+				.orElseThrow(() -> new NotMatchRankingPeriodException("일치하는 랭킹 집계 기간이 없습니다."));
+	}
+}

--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -34,7 +34,10 @@ import com.recordit.server.dto.record.WriteRecordResponseDto;
 import com.recordit.server.dto.record.memory.MemoryRecordRequestDto;
 import com.recordit.server.dto.record.memory.MemoryRecordResponseDto;
 import com.recordit.server.dto.record.mix.MixRecordResponseDto;
+import com.recordit.server.dto.record.ranking.RecordRankingRequestDto;
+import com.recordit.server.dto.record.ranking.RecordRankingResponseDto;
 import com.recordit.server.exception.ErrorMessage;
+import com.recordit.server.service.RecordRankingService;
 import com.recordit.server.service.RecordService;
 
 import io.swagger.annotations.ApiOperation;
@@ -49,6 +52,7 @@ import lombok.RequiredArgsConstructor;
 public class RecordController {
 
 	private final RecordService recordService;
+	private final RecordRankingService recordRankingService;
 
 	@ApiOperation(
 			value = "레코드 작성",
@@ -244,4 +248,28 @@ public class RecordController {
 	) {
 		return ResponseEntity.ok().body(recordService.getRecordsBySearch(recordBySearchRequestDto));
 	}
+
+	@ApiOperation(
+			value = "레코드 카테고리를 통해 댓글의 갯수를 기준으로 랭킹을 조회",
+			notes = "레코드 카테고리를 통해 댓글의 갯수를 기준으로 랭킹을 조회합니다. \t\n"
+					+ "상위 카테고리를 지정할 경우 전체 조회를 하고, 하위 카테고리를 지정할 경우 해당 하위 카테고리의 랭킹을 조회합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "레코드 랭킹 조회 성공",
+					response = RecordRankingResponseDto.class
+			),
+			@ApiResponse(
+					code = 400,
+					message = "잘못 된 요청",
+					response = ErrorMessage.class
+			)
+	})
+	@GetMapping("/ranking")
+	public ResponseEntity<RecordRankingResponseDto> getRecordByCategorySortByComments(
+			@ModelAttribute @Valid RecordRankingRequestDto recordRankingRequestDto
+	) {
+		return ResponseEntity.ok(recordRankingService.getRecordRanking(recordRankingRequestDto));
+	}
+
 }

--- a/src/main/java/com/recordit/server/converter/RankingPeriodConverter.java
+++ b/src/main/java/com/recordit/server/converter/RankingPeriodConverter.java
@@ -1,0 +1,13 @@
+package com.recordit.server.converter;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.recordit.server.constant.RankingPeriod;
+
+public class RankingPeriodConverter implements Converter<String, RankingPeriod> {
+
+	@Override
+	public RankingPeriod convert(String source) {
+		return RankingPeriod.findByString(source);
+	}
+}

--- a/src/main/java/com/recordit/server/domain/Record.java
+++ b/src/main/java/com/recordit/server/domain/Record.java
@@ -1,5 +1,8 @@
 package com.recordit.server.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import org.hibernate.annotations.SQLDelete;
@@ -53,6 +57,9 @@ public class Record extends BaseEntity {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "RECORD_ICON_ID")
 	private RecordIcon recordIcon;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "record")
+	private List<Comment> comments = new ArrayList<>();
 
 	private Record(
 			RecordCategory recordCategory,

--- a/src/main/java/com/recordit/server/domain/RecordCategory.java
+++ b/src/main/java/com/recordit/server/domain/RecordCategory.java
@@ -17,6 +17,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 @Where(clause = "DELETED_AT is null")
 @SQLDelete(sql = "UPDATE RECORD_CATEGORY SET RECORD_CATEGORY.DELETED_AT = CURRENT_TIMESTAMP WHERE RECORD_CATEGORY.RECORD_CATEGORY_ID = ?")
 @Getter
+@EqualsAndHashCode(of = {"id", "name"})
 public class RecordCategory extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingDto.java
@@ -1,0 +1,56 @@
+package com.recordit.server.dto.record.ranking;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordRankingDto {
+
+	@ApiModelProperty(notes = "레코드 ID")
+	private Long recordId;
+
+	@ApiModelProperty(notes = "레코드 제목")
+	private String title;
+
+	@ApiModelProperty(notes = "레코드 작성자")
+	private String writer;
+
+	@ApiModelProperty(notes = "레코드 컬러 이름")
+	private String colorName;
+
+	@ApiModelProperty(notes = "레코드 아이콘 이름")
+	private String iconName;
+
+	@ApiModelProperty(notes = "레코드에 달린 댓글의 갯수")
+	private Integer numOfComment;
+
+	private RecordRankingDto(Long recordId, String title, String writer, String colorName, String iconName,
+			Integer numOfComment) {
+		this.recordId = recordId;
+		this.title = title;
+		this.writer = writer;
+		this.colorName = colorName;
+		this.iconName = iconName;
+		this.numOfComment = numOfComment;
+	}
+
+	public static RecordRankingDto of(Record record) {
+		return new RecordRankingDto(
+				record.getId(),
+				record.getTitle(),
+				record.getWriter().getNickname(),
+				record.getRecordColor().getName(),
+				record.getRecordIcon().getName(),
+				record.getComments().size()
+		);
+	}
+}

--- a/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingRequestDto.java
@@ -1,0 +1,28 @@
+package com.recordit.server.dto.record.ranking;
+
+import javax.validation.constraints.NotNull;
+
+import com.recordit.server.constant.RankingPeriod;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiParam;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class RecordRankingRequestDto {
+
+	@ApiParam(value = "조회 할 레코드 카테고리 ID", required = true)
+	@NotNull(message = "레코드 카테고리 ID를 지정해야 합니다")
+	private Long recordCategoryId;
+
+	@ApiParam(value = "조회 할 랭킹의 집계 범위", required = true)
+	@NotNull(message = "랭킹 집계 범위를 지정해야 합니다")
+	private RankingPeriod rankingPeriod;
+
+}

--- a/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
@@ -1,9 +1,6 @@
 package com.recordit.server.dto.record.ranking;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import com.recordit.server.domain.Record;
 
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
@@ -23,10 +20,7 @@ public class RecordRankingResponseDto {
 		this.recordRankingDtos = recordRankingDtos;
 	}
 
-	public static RecordRankingResponseDto of(List<Record> records) {
-		List<RecordRankingDto> mapToRecordRankingDtos = records.stream()
-				.map(RecordRankingDto::of)
-				.collect(Collectors.toList());
-		return new RecordRankingResponseDto(mapToRecordRankingDtos);
+	public static RecordRankingResponseDto of(List<RecordRankingDto> recordRankingDtos) {
+		return new RecordRankingResponseDto(recordRankingDtos);
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
@@ -1,0 +1,32 @@
+package com.recordit.server.dto.record.ranking;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordRankingResponseDto {
+
+	private List<RecordRankingDto> recordRankingDtos;
+
+	private RecordRankingResponseDto(List<RecordRankingDto> recordRankingDtos) {
+		this.recordRankingDtos = recordRankingDtos;
+	}
+
+	public static RecordRankingResponseDto of(List<Record> records) {
+		List<RecordRankingDto> mapToRecordRankingDtos = records.stream()
+				.map(RecordRankingDto::of)
+				.collect(Collectors.toList());
+		return new RecordRankingResponseDto(mapToRecordRankingDtos);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/NotMatchRankingPeriodException.java
+++ b/src/main/java/com/recordit/server/exception/record/NotMatchRankingPeriodException.java
@@ -1,0 +1,7 @@
+package com.recordit.server.exception.record;
+
+public class NotMatchRankingPeriodException extends RuntimeException {
+	public NotMatchRankingPeriodException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
@@ -63,4 +63,11 @@ public class RecordExceptionHandler {
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
+
+	@ExceptionHandler(NotMatchRankingPeriodException.class)
+	public ResponseEntity<ErrorMessage> handleNotMatchRankingPeriodException(
+			NotMatchRankingPeriodException exception) {
+		return ResponseEntity.badRequest()
+				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
 }

--- a/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordCategoryRepository.java
@@ -1,11 +1,28 @@
 package com.recordit.server.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.recordit.server.domain.RecordCategory;
 
 public interface RecordCategoryRepository extends JpaRepository<RecordCategory, Long> {
 	List<RecordCategory> findAllByParentRecordCategory(RecordCategory parentRecordCategory);
+
+	@EntityGraph(attributePaths = {"subcategories"})
+	@Query(value = "select rc "
+			+ "from RECORD_CATEGORY rc "
+			+ "left join rc.subcategories")
+	List<RecordCategory> findAllFetchSubCategories();
+
+	@EntityGraph(attributePaths = {"subcategories"})
+	@Query(value = "select rc "
+			+ "from RECORD_CATEGORY rc "
+			+ "left join rc.subcategories "
+			+ "where rc.id = :recordCategoryId")
+	Optional<RecordCategory> findByIdFetchSubCategories(@Param("recordCategoryId") Long recordCategoryId);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.recordit.server.domain.Member;
 import com.recordit.server.domain.Record;
+import com.recordit.server.domain.RecordCategory;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
@@ -74,4 +75,27 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			String searchKeyword,
 			Pageable pageable
 	);
+
+	@EntityGraph(attributePaths = {"writer", "recordCategory", "comments", "recordIcon", "recordColor"})
+	@Query(value = "select r "
+			+ "from RECORD r "
+			+ "left join r.writer "
+			+ "left join r.recordCategory "
+			+ "left join r.comments "
+			+ "left join r.recordIcon "
+			+ "left join r.recordColor"
+	)
+	List<Record> findAllFetchAll();
+
+	@EntityGraph(attributePaths = {"writer", "recordCategory", "comments", "recordIcon", "recordColor"})
+	@Query(value = "select r "
+			+ "from RECORD r "
+			+ "left join r.writer "
+			+ "left join r.recordCategory "
+			+ "left join r.comments "
+			+ "left join r.recordIcon "
+			+ "left join r.recordColor "
+			+ "where r.recordCategory = :recordCategory"
+	)
+	List<Record> findAllByRecordCategoryFetchAll(@Param("recordCategory") RecordCategory recordCategory);
 }

--- a/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
+++ b/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
@@ -1,0 +1,25 @@
+package com.recordit.server.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.recordit.server.service.RecordRankingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecordRankingScheduler {
+
+	private final RecordRankingService recordRankingService;
+
+	// 매 30분 마다
+	@Scheduled(cron = "0 0/30 * * * ?")
+	public void updateRecordRanking() {
+		log.info("레코드 랭킹 집계 스케쥴러 실행");
+		recordRankingService.updateRecordRanking();
+		log.info("레코드 랭킹 집계 성공");
+	}
+}

--- a/src/main/java/com/recordit/server/service/RecordRankingProvider.java
+++ b/src/main/java/com/recordit/server/service/RecordRankingProvider.java
@@ -1,0 +1,76 @@
+package com.recordit.server.service;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import com.recordit.server.constant.RankingPeriod;
+import com.recordit.server.domain.Record;
+import com.recordit.server.domain.RecordCategory;
+import com.recordit.server.dto.record.ranking.RecordRankingDto;
+import com.recordit.server.util.DateTimeUtil;
+
+@Component
+public class RecordRankingProvider {
+
+	private static final Integer SIZE_OF_RANKING_RECORD = 10;
+
+	@Cacheable(value = "RecordRanking", key = "{#rankingPeriod, #recordCategory.id}")
+	public List<RecordRankingDto> getRecordRanking(
+			List<Record> records,
+			RankingPeriod rankingPeriod,
+			RecordCategory recordCategory
+	) {
+		List<Record> recordsAfter = getRecordsAfter(records, rankingPeriod);
+		List<Record> recordInCategory = getRecordInCategory(recordsAfter, recordCategory);
+		List<Record> sortedRecords = sortByNumOfComment(recordInCategory);
+		List<Record> topRankRecords = filterTopRankRecord(sortedRecords);
+		return topRankRecords.stream().map(RecordRankingDto::of).collect(Collectors.toList());
+	}
+
+	@CachePut(value = "RecordRanking", key = "{#rankingPeriod, #recordCategory.id}")
+	public List<RecordRankingDto> updateRecordRanking(
+			List<Record> records,
+			RankingPeriod rankingPeriod,
+			RecordCategory recordCategory
+	) {
+		List<Record> recordsAfter = getRecordsAfter(records, rankingPeriod);
+		List<Record> recordInCategory = getRecordInCategory(recordsAfter, recordCategory);
+		List<Record> sortedRecords = sortByNumOfComment(recordInCategory);
+		List<Record> topRankRecords = filterTopRankRecord(sortedRecords);
+		return topRankRecords.stream().map(RecordRankingDto::of).collect(Collectors.toList());
+	}
+
+	private List<Record> getRecordsAfter(List<Record> records, RankingPeriod rankingPeriod) {
+		LocalDateTime start = DateTimeUtil.getBeforePeriodFromNow(rankingPeriod);
+		return records.stream()
+				.filter(record -> record.getCreatedAt().isAfter(start))
+				.collect(Collectors.toList());
+	}
+
+	private List<Record> getRecordInCategory(List<Record> records, RecordCategory recordCategory) {
+		return records.stream()
+				// 상위 카테고리의 경우 자신의 하위 카테고리를 모두 포함하여 구하도록 함
+				.filter(record -> record.getRecordCategory().equals(recordCategory)
+						|| recordCategory.getSubcategories().contains(record.getRecordCategory())
+				)
+				.collect(Collectors.toList());
+	}
+
+	private List<Record> sortByNumOfComment(List<Record> records) {
+		return records.stream()
+				.sorted(Comparator.comparing((Record record) -> record.getComments().size()).reversed())
+				.collect(Collectors.toList());
+	}
+
+	private List<Record> filterTopRankRecord(List<Record> records) {
+		return records.stream()
+				.limit(SIZE_OF_RANKING_RECORD)
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/recordit/server/service/RecordRankingService.java
+++ b/src/main/java/com/recordit/server/service/RecordRankingService.java
@@ -1,0 +1,56 @@
+package com.recordit.server.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.recordit.server.constant.RankingPeriod;
+import com.recordit.server.domain.Record;
+import com.recordit.server.domain.RecordCategory;
+import com.recordit.server.dto.record.ranking.RecordRankingDto;
+import com.recordit.server.dto.record.ranking.RecordRankingRequestDto;
+import com.recordit.server.dto.record.ranking.RecordRankingResponseDto;
+import com.recordit.server.exception.record.category.RecordCategoryNotFoundException;
+import com.recordit.server.repository.RecordCategoryRepository;
+import com.recordit.server.repository.RecordRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecordRankingService {
+
+	private final RecordRankingProvider recordRankingProvider;
+	private final RecordRepository recordRepository;
+	private final RecordCategoryRepository recordCategoryRepository;
+
+	@Transactional(readOnly = true)
+	public RecordRankingResponseDto getRecordRanking(RecordRankingRequestDto recordRankingRequestDto) {
+		RecordCategory recordCategory = recordCategoryRepository.findByIdFetchSubCategories(
+				recordRankingRequestDto.getRecordCategoryId()
+		).orElseThrow(() -> new RecordCategoryNotFoundException("지정한 레코드 카테고리가 존재하지 않습니다."));
+		List<Record> findRecords = recordRepository.findAllByRecordCategoryFetchAll(recordCategory);
+
+		List<RecordRankingDto> recordRanking = recordRankingProvider.getRecordRanking(
+				findRecords,
+				recordRankingRequestDto.getRankingPeriod(),
+				recordCategory
+		);
+
+		return RecordRankingResponseDto.of(recordRanking);
+	}
+
+	@Transactional(readOnly = true)
+	public void updateRecordRanking() {
+		List<Record> allRecords = recordRepository.findAllFetchAll();
+		List<RecordCategory> allRecordCategories = recordCategoryRepository.findAllFetchSubCategories();
+		for (RankingPeriod rankingPeriod : RankingPeriod.values()) {
+			for (RecordCategory recordCategory : allRecordCategories) {
+				recordRankingProvider.updateRecordRanking(allRecords, rankingPeriod, recordCategory);
+			}
+		}
+	}
+}

--- a/src/main/java/com/recordit/server/util/DateTimeUtil.java
+++ b/src/main/java/com/recordit/server/util/DateTimeUtil.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import com.recordit.server.constant.RankingPeriod;
+
 public class DateTimeUtil {
 
 	public static LocalDateTime getStartOfToday() {
@@ -16,5 +18,17 @@ public class DateTimeUtil {
 
 	public static LocalDateTime getEndOfDay(LocalDate localDate) {
 		return LocalDateTime.of(localDate, LocalTime.MAX);
+	}
+
+	public static LocalDateTime getBeforePeriodFromNow(RankingPeriod rankingPeriod) {
+		LocalDateTime now = LocalDateTime.now();
+		if (rankingPeriod == RankingPeriod.DAY) {
+			return now.minusDays(1);
+		} else if (rankingPeriod == RankingPeriod.WEEK) {
+			return now.minusWeeks(1);
+		} else if (rankingPeriod == RankingPeriod.MONTH) {
+			return now.minusMonths(1);
+		}
+		return LocalDateTime.MIN;
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호

[BE-200 / 랭킹 시스템 구현](https://recodeit.atlassian.net/browse/BE-200)

## 설명
- 레코드 랭킹 집계한 내용을 30분마다 업데이트 하기 위해 스케쥴러 추가
- 랭킹 집계 기간을 정의하는 RankingPeriod 추가
    - Controller에서 바로 RankingPeriod로 매핑하는 Converter 추가
    - RankingPeriod 매핑 실패시 Exception 추가
- Record Entity에 Comment 양방향 매핑 추가
- RecordCategory에 equals와 hashcode 재정의
- 랭킹 관련 DTO 추가
- RecordRankingService 추가
    -  RecordRankingProvider을 사용해 집계된 랭킹을 반환함
- RecordRankingProvider 추가
    - 레코드와 집계기간을 통해 레코드의 랭킹을 집계함 

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
