### PR TITLE
[BE-215] 레코드 랭킹 조회시 상위 카테고리를 통해 조회할 경우 하위 카테고리가 포함되지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -95,9 +95,9 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			+ "left join r.comments "
 			+ "left join r.recordIcon "
 			+ "left join r.recordColor "
-			+ "where r.recordCategory = :recordCategory"
+			+ "where r.recordCategory in :recordCategories"
 	)
-	List<Record> findAllByRecordCategoryFetchAll(@Param("recordCategory") RecordCategory recordCategory);
+	List<Record> findAllInRecordCategoryFetchAll(@Param("recordCategories") List<RecordCategory> recordCategories);
 
 	List<Record> findAllByWriterAndCreatedAtBetween(
 			Member writer,

--- a/src/main/java/com/recordit/server/service/RecordRankingService.java
+++ b/src/main/java/com/recordit/server/service/RecordRankingService.java
@@ -32,7 +32,10 @@ public class RecordRankingService {
 		RecordCategory recordCategory = recordCategoryRepository.findByIdFetchSubCategories(
 				recordRankingRequestDto.getRecordCategoryId()
 		).orElseThrow(() -> new RecordCategoryNotFoundException("지정한 레코드 카테고리가 존재하지 않습니다."));
-		List<Record> findRecords = recordRepository.findAllByRecordCategoryFetchAll(recordCategory);
+
+		List<RecordCategory> parentCategoryAndSubCategories = recordCategory.getSubcategories();
+		parentCategoryAndSubCategories.add(recordCategory);
+		List<Record> findRecords = recordRepository.findAllInRecordCategoryFetchAll(parentCategoryAndSubCategories);
 
 		List<RecordRankingDto> recordRanking = recordRankingProvider.getRecordRanking(
 				findRecords,
@@ -53,4 +56,5 @@ public class RecordRankingService {
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [BE-215 / 레코드 랭킹 조회시 상위 카테고리를 통해 조회할 경우 하위 카테고리가 포함되지 않는 버그 픽스](https://recodeit.atlassian.net/browse/BE-215) -->

## 설명
- 레코드 랭킹 조회시 상위 카테고리를 통해 조회할 경우 하위 카테고리가 포함되지 않고 레코드가 조회 되는 버그 발생
    - 해당 부분을 상위 카테고리로 조회시 하위 카테고리들과 전체 카테고리를 담은 list를 통해 jpql in 연산자로 픽스 

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
