### PR TITLE
[BE-212] 테스트서버 CI/CD를 위한 github Actions yml파일 작성

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,120 @@
+name: Deploy to cloudtype
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Connect deploy key
+        uses: cloudtype-github-actions/connect@v1
+        with:
+          token: ${{ secrets.CLOUDTYPE_TOKEN }}
+          ghtoken: ${{ secrets.GHP_TOKEN }}
+      - name: Deploy
+        uses: cloudtype-github-actions/deploy@v1
+        with:
+          token: ${{ secrets.CLOUDTYPE_TOKEN }}
+          project: kdomo/tengers
+          stage: dev
+          yaml: >
+            name: recodeit-server
+
+            app: java@11
+
+            options:
+              ports: 8080
+              env:
+                - name: DATASOURCE_HOST
+                  value: ${{ secrets.DEV_DATASOURCE_HOST }}
+                - name: DATASOURCE_PORT
+                  value: ${{ secrets.DEV_DATASOURCE_PORT }}
+                - name: DATASOURCE_USERNAME
+                  value: ${{ secrets.DEV_DATASOURCE_USERNAME }}
+                - name: DATASOURCE_PASSWORD
+                  value: ${{ secrets.DEV_DATASOURCE_PASSWORD }}
+                - name: REDIS_HOST
+                  value: ${{ secrets.DEV_REDIS_HOST }}
+                - name: REDIS_PORT
+                  value: ${{ secrets.DEV_REDIS_PORT }}
+                - name: REDIS_PASSWORD
+                  value: ${{ secrets.DEV_REDIS_PASSWORD }}
+                - name: SPRING_PROFILES_ACTIVE
+                  value: ${{ secrets.DEV_SPRING_PROFILES_ACTIVE }}
+                - name: OAUTH_KAKAO_CLIENT_ID
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_CLIENT_ID }}
+                - name: OAUTH_KAKAO_CLIENT_SECRET
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_CLIENT_SECRET }}
+                - name: OAUTH_KAKAO_REDIRECT_URL
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_REDIRECT_URL }}
+                - name: OAUTH_GOOGLE_CLIENT_ID
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_CLIENT_ID }}
+                - name: OAUTH_GOOGLE_CLIENT_SECRET
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_CLIENT_SECRET }}
+                - name: OAUTH_GOOGLE_REDIRECT_URL
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_REDIRECT_URL }}
+                - name: S3_ACCESS_KEY
+                  value: ${{ secrets.DEV_S3_ACCESS_KEY }}
+                - name: S3_SECRET_ACCESS_KEY
+                  value: ${{ secrets.DEV_S3_SECRET_ACCESS_KEY }}
+                - name: S3_BUCKET_NAME
+                  value: ${{ secrets.DEV_S3_BUCKET_NAME }}
+                - name: S3_DIRECTORY_NAME
+                  value: ${{ secrets.DEV_S3_DIRECTORY_NAME }}
+                - name: TZ
+                  value: ${{ secrets.TZ }}
+                - name: CORS_ORIGIN_NAME
+                  value: ${{ secrets.DEV_CORS_ORIGIN_NAME }}
+              build: ./gradlew clean build
+              buildenv:
+                - name: OAUTH_KAKAO_CLIENT_ID
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_CLIENT_ID }}
+                - name: OAUTH_KAKAO_CLIENT_SECRET
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_CLIENT_SECRET }}
+                - name: OAUTH_KAKAO_REDIRECT_URL
+                  value: ${{ secrets.DEV_OAUTH_KAKAO_REDIRECT_URL }}
+                - name: OAUTH_GOOGLE_CLIENT_ID
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_CLIENT_ID }}
+                - name: OAUTH_GOOGLE_CLIENT_SECRET
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_CLIENT_SECRET }}
+                - name: OAUTH_GOOGLE_REDIRECT_URL
+                  value: ${{ secrets.DEV_OAUTH_GOOGLE_REDIRECT_URL }}
+                - name: S3_ACCESS_KEY
+                  value: ${{ secrets.DEV_S3_ACCESS_KEY }}
+                - name: S3_SECRET_ACCESS_KEY
+                  value: ${{ secrets.DEV_S3_SECRET_ACCESS_KEY }}
+                - name: S3_BUCKET_NAME
+                  value: ${{ secrets.DEV_S3_BUCKET_NAME }}
+                - name: S3_DIRECTORY_NAME
+                  value: ${{ secrets.DEV_S3_DIRECTORY_NAME }}
+                - name: CORS_ORIGIN_NAME
+                  value: ${{ secrets.DEV_CORS_ORIGIN_NAME }}
+            context:
+              git:
+                url: git@github.com:${{ github.repository }}.git
+                ref: ${{ github.ref }}
+      - name: Notify on success
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.DEV_SLACK_WEBHOOK }}
+          SLACK_CHANNEL: ${{ secrets.DEV_SLACK_CHANNEL }}
+          SLACK_COLOR: '#703CDE'
+          SLACK_USERNAME: DEV Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_TITLE: Message
+          SLACK_MESSAGE: '테스트 서버 Build succeeded! :짠:'
+      - name: Notify on failure
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.DEV_SLACK_WEBHOOK }}
+          SLACK_CHANNEL: ${{ secrets.DEV_SLACK_CHANNEL }}
+          SLACK_COLOR: '#F33D63'
+          SLACK_USERNAME: DEV Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_TITLE: Message
+          SLACK_MESSAGE: '테스트 서버 Build failed! :울다:'


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-212 / 테스트서버 CI/CD를 위한 github Actions yml파일 작성](https://recodeit.atlassian.net/browse/BE-212)

## 설명
테스트 서버 CI/CD를 위한 github Actions yml파일 작성하였습니다.
`cloudtype-github-actions/deploy@v1`을 사용하여 클라우드 타입에 배포 hook을 발송합니다.

빌드와 배포가 모두 진행되며, 배포 결과에 따라 슬랙에 메세지가 전송됩니다.

## 변경사항
- [x] ./github/workflows/deploy-dev.yml 파일 생성

## 질문사항