### PR TITLE
[BE-216] 전체 레코드 수 반환 기능 구현

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -274,11 +274,24 @@ public class RecordController {
 		return ResponseEntity.ok(recordRankingService.getRecordRanking(recordRankingRequestDto));
 	}
 
-
 	@GetMapping("/days")
 	public ResponseEntity<WrittenRecordDayResponseDto> getWrittenRecordDays(
 			@Valid WrittenRecordDayRequestDto writtenRecordDayRequestDto
 	) {
 		return ResponseEntity.ok(recordService.getWrittenRecordDays(writtenRecordDayRequestDto));
+	}
+
+	@ApiOperation(
+			value = "레코드의 전체 개수 반환",
+			notes = "레코드의 전체 개수를 반환합니다."
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "레코드 전체 개수 조회 성공"
+			)
+	})
+	@GetMapping("/count")
+	public ResponseEntity<Long> getRecordAllCount() {
+		return ResponseEntity.ok(recordService.getRecordAllCount());
 	}
 }

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -11,6 +11,8 @@ import java.util.Random;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -84,6 +86,7 @@ public class RecordService {
 	private final CommentRepository commentRepository;
 
 	@Transactional
+	@CacheEvict(value = "RecordAllCount", allEntries = true)
 	public WriteRecordResponseDto writeRecord(WriteRecordRequestDto writeRecordRequestDto,
 			List<MultipartFile> attachments) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
@@ -229,6 +232,7 @@ public class RecordService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "RecordAllCount", allEntries = true)
 	public void deleteRecord(Long recordId) {
 		Long userIdBySession = sessionUtil.findUserIdBySession();
 		log.info("세션에서 찾은 사용자 ID : {}", userIdBySession);
@@ -416,5 +420,10 @@ public class RecordService {
 						.collect(Collectors.toCollection(TreeSet::new));
 
 		return WrittenRecordDayResponseDto.of(writtenRecordDays);
+	}
+
+	@Cacheable(value = "RecordAllCount")
+	public long getRecordAllCount() {
+		return recordRepository.count();
 	}
 }

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -745,4 +745,18 @@ class RecordServiceTest {
 			assertThat(writtenRecordDays.getWrittenRecordDayDto().contains(2)).isTrue();
 		}
 	}
+
+	@Test
+	@DisplayName("레코드의 개수를 반환한다")
+	void 레코드의_개수를_반환한다() {
+		//given
+		given(recordRepository.count())
+				.willReturn(172L);
+		//when
+		Long recordAllCount = recordService.getRecordAllCount();
+		//then
+		assertThat(recordAllCount).isEqualTo(172L);
+		assertThatCode(() -> recordService.getRecordAllCount())
+				.doesNotThrowAnyException();
+	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-216 / 전체 레코드 수 반환 기능 구현](https://recodeit.atlassian.net/browse/BE-216)

## 설명
모아보기에서 전체 레코드 개수를 확인할 수 있도록
전체 레코드 수를 반환하는 API 구현하였습니다.

카운트 쿼리를 최소화 하기위해 전체 레코드 수 조회 메서드에서 캐시를 적극 사용하였고,
데이터의 정합성을 위해 글 작성과 글 삭제 시 캐시를 비워주도록 하였습니다.

## 변경사항


## 질문사항
jpa 의 count 메서드가 primitive 타입인 long을 반환하도록 바뀐 것 같습니다.
RecordService.java getRecordAllCount 메소드의 반환값을 Wrapper로 설정하고, count쿼리의 결괏값을 boxing하여 return하도록 작성하였더니, `java.lang.ClassCastException`가 발생합니다. 이유가 뭘까요...? 