### PR TITLE
[BE-228] fix: 마이레코드 단건조회 limit 적용

### DIFF
--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -37,7 +37,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	);
 
 	@EntityGraph(attributePaths = {"writer", "recordCategory", "recordIcon", "recordColor"})
-	Optional<Record> findAllByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
+	Optional<Record> findFirstByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
 			Member writer,
 			LocalDateTime startTime,
 			LocalDateTime endTime

--- a/src/main/java/com/recordit/server/service/RecordService.java
+++ b/src/main/java/com/recordit/server/service/RecordService.java
@@ -160,7 +160,7 @@ public class RecordService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
-		Record record = recordRepository.findAllByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
+		Record record = recordRepository.findFirstByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
 				member,
 				getStartOfDay(LocalDate.now()),
 				getEndOfDay(LocalDate.now())

--- a/src/test/java/com/recordit/server/service/RecordServiceTest.java
+++ b/src/test/java/com/recordit/server/service/RecordServiceTest.java
@@ -380,7 +380,7 @@ class RecordServiceTest {
 			// given
 			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
-			given(recordRepository.findAllByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(any(), any(), any()))
+			given(recordRepository.findFirstByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(any(), any(), any()))
 					.willReturn(Optional.empty());
 
 			// when, then
@@ -395,7 +395,7 @@ class RecordServiceTest {
 			//given
 			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
-			given(recordRepository.findAllByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(any(), any(), any()))
+			given(recordRepository.findFirstByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(any(), any(), any()))
 					.willReturn(Optional.of(mockRecord));
 			given(mockRecord.getId())
 					.willReturn(1L);


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-228 / 마이레코드 단건조회 limit 적용](https://recodeit.atlassian.net/browse/BE-228)

## 설명
limit이 적용되어있지 않아 limit 적용하였습니다

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
