### PR TITLE
[BE-229] github actions 환경변수 변경 및 알림 커밋메세지 알림 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -91,7 +91,7 @@ jobs:
                 - name: S3_DIRECTORY_NAME
                   value: ${{ secrets.DEV_S3_DIRECTORY_NAME }}
                 - name: CORS_ORIGIN_NAME
-                  value: ${{ secrets.DEV_CORS_ORIGIN_NAME }}
+                  value: CORS_ORIGIN_NAME
             context:
               git:
                 url: git@github.com:${{ github.repository }}.git
@@ -106,9 +106,7 @@ jobs:
           SLACK_USERNAME: DEV Bot
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           SLACK_TITLE: Message
-          SLACK_MESSAGE: '테스트 서버 Build succeeded 🎉'
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, '\n') }}
+          SLACK_MESSAGE: "테스트 서버 Build succeeded 🎉 \n\n *CommitMessage* \n ${{ join(github.event.commits.*.message, '\n') }}"
       - name: Notify on failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
@@ -119,6 +117,4 @@ jobs:
           SLACK_USERNAME: DEV Bot
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           SLACK_TITLE: Message
-          SLACK_MESSAGE: '테스트 서버 Build failed 🥲'
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, '\n') }}
+          SLACK_MESSAGE: "테스트 서버 Build failed 🥲 \n\n *CommitMessage* \n ${{ join(github.event.commits.*.message, '\n') }}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -68,9 +68,7 @@ jobs:
           SLACK_USERNAME: PROD Bot
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           SLACK_TITLE: Message
-          SLACK_MESSAGE: '상용 서버 Build succeeded 🎉'
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, '\n') }}
+          SLACK_MESSAGE: "상용 서버 Build succeeded 🎉 \n\n *CommitMessage* \n ${{ join(github.event.commits.*.message, '\n') }}"
       - name: Notify on failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
@@ -81,6 +79,4 @@ jobs:
           SLACK_USERNAME: PROD Bot
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           SLACK_TITLE: Message
-          SLACK_MESSAGE: '상용 서버 Build failed 🥲'
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, '\n') }}
+          SLACK_MESSAGE: "상용 서버 Build failed 🥲 \n\n *CommitMessage* \n ${{ join(github.event.commits.*.message, '\n') }}"


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-229 / github actions 환경변수 변경 및 알림 커밋메세지 알림 수정](https://recodeit.atlassian.net/browse/BE-229)

## 설명
1.slack 알림 시 커밋 메세지까지 포함하여 알림을 발송하도록 변경하였습니다.
2.CORS_ORIGIN_NAME에 특수문자가 적용되지 않아 cloudtype내 secret을 사용하도록 변경하였습니다.

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
