### PR TITLE
[BE-230] refactor: 추억레코드 날짜 선택도 가능하도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/controller/RecordController.java
+++ b/src/main/java/com/recordit/server/controller/RecordController.java
@@ -131,7 +131,7 @@ public class RecordController {
 	})
 	@GetMapping("/memory")
 	public ResponseEntity<MemoryRecordResponseDto> getMemoryRecordList(
-			@ModelAttribute @Valid MemoryRecordRequestDto memoryRecordRequestDto
+			@Valid MemoryRecordRequestDto memoryRecordRequestDto
 	) {
 		return ResponseEntity.ok().body(recordService.getMemoryRecords(memoryRecordRequestDto));
 	}

--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordCommentDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordCommentDto.java
@@ -1,9 +1,10 @@
 package com.recordit.server.dto.record.memory;
 
+import com.recordit.server.domain.Comment;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -19,10 +20,21 @@ public class MemoryRecordCommentDto {
 	@ApiModelProperty(notes = "추억레코드 댓글 내용")
 	private String content;
 
-	@Builder
-	public MemoryRecordCommentDto(Long commentId, String content) {
+	private MemoryRecordCommentDto(
+			Long commentId,
+			String content
+	) {
 		this.commentId = commentId;
 		this.content = content;
+	}
+
+	public static MemoryRecordCommentDto of(
+			Comment comment
+	) {
+		return new MemoryRecordCommentDto(
+				comment.getId(),
+				comment.getContent()
+		);
 	}
 
 }

--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordDto.java
@@ -4,11 +4,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.recordit.server.domain.Comment;
+import com.recordit.server.domain.Record;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -33,25 +33,32 @@ public class MemoryRecordDto {
 	@ApiModelProperty(notes = "추억 레코드 댓글 리스트")
 	private List<MemoryRecordCommentDto> memoryRecordComments;
 
-	@Builder
-	public MemoryRecordDto(
+	private MemoryRecordDto(
 			Long recordId,
 			String title,
 			String iconName,
 			String colorName,
-			List<Comment> memoryRecordComments
+			List<MemoryRecordCommentDto> memoryRecordComments
 	) {
 		this.recordId = recordId;
 		this.title = title;
 		this.iconName = iconName;
 		this.colorName = colorName;
-		this.memoryRecordComments = memoryRecordComments.stream()
-				.map(
-						comment -> MemoryRecordCommentDto.builder()
-								.commentId(comment.getId())
-								.content(comment.getContent())
-								.build()
-				)
-				.collect(Collectors.toList());
+		this.memoryRecordComments = memoryRecordComments;
+	}
+
+	public static MemoryRecordDto of(
+			Record record,
+			List<Comment> memoryRecordComments
+	) {
+		return new MemoryRecordDto(
+				record.getId(),
+				record.getTitle(),
+				record.getRecordIcon().getName(),
+				record.getRecordColor().getName(),
+				memoryRecordComments.stream()
+						.map(comment -> MemoryRecordCommentDto.of(comment))
+						.collect(Collectors.toList())
+		);
 	}
 }

--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordRequestDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordRequestDto.java
@@ -1,7 +1,11 @@
 package com.recordit.server.dto.record.memory;
 
+import java.time.LocalDate;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.annotations.ApiParam;
 import lombok.AccessLevel;
@@ -13,6 +17,10 @@ import lombok.ToString;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemoryRecordRequestDto {
+
+	@ApiParam(value = "조회할 날짜", example = "2022-11-16")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate date;
 
 	@ApiParam(value = "추억 레코드 조회 페이지 !주의: 0부터 시작", required = true, example = "0")
 	@NotNull

--- a/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/memory/MemoryRecordResponseDto.java
@@ -12,7 +12,6 @@ import com.recordit.server.domain.Record;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -32,22 +31,26 @@ public class MemoryRecordResponseDto {
 	@ApiModelProperty(notes = "추억 레코드 리스트")
 	private List<MemoryRecordDto> memoryRecordList;
 
-	@Builder
-	public MemoryRecordResponseDto(
+	private MemoryRecordResponseDto(
+			Integer totalPage,
+			Long totalCount,
+			List<MemoryRecordDto> memoryRecordList
+	) {
+		this.totalPage = totalPage;
+		this.totalCount = totalCount;
+		this.memoryRecordList = memoryRecordList;
+	}
+
+	public static MemoryRecordResponseDto of(
 			Page<Record> memoryRecords,
 			Map<Record, List<Comment>> recordToComments
 	) {
-		this.totalPage = memoryRecords.getTotalPages();
-		this.totalCount = memoryRecords.getTotalElements();
-		this.memoryRecordList = memoryRecords.stream()
-				.map(
-						record -> MemoryRecordDto.builder()
-								.recordId(record.getId())
-								.title(record.getTitle())
-								.colorName(record.getRecordColor().getName())
-								.iconName(record.getRecordIcon().getName())
-								.memoryRecordComments(recordToComments.get(record))
-								.build()
-				).collect(Collectors.toList());
+		return new MemoryRecordResponseDto(
+				memoryRecords.getTotalPages(),
+				memoryRecords.getTotalElements(),
+				memoryRecords.stream()
+						.map(record -> MemoryRecordDto.of(record, recordToComments.get(record)))
+						.collect(Collectors.toList())
+		);
 	}
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -37,6 +37,14 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	);
 
 	@EntityGraph(attributePaths = {"writer", "recordCategory", "recordIcon", "recordColor"})
+	Page<Record> findAllByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
+			Member writer,
+			LocalDateTime startTime,
+			LocalDateTime endTime,
+			Pageable pageable
+	);
+
+	@EntityGraph(attributePaths = {"writer", "recordCategory", "recordIcon", "recordColor"})
 	Optional<Record> findFirstByWriterAndCreatedAtBetweenOrderByCreatedAtDesc(
 			Member writer,
 			LocalDateTime startTime,


### PR DESCRIPTION
## 관련 이슈 번호
 - [BE-230 / 추억레코드 날짜 선택도 가능하도록 변경](https://recodeit.atlassian.net/browse/BE-230)

## 설명
기존 추억레코드 API에서 날짜를 선택하면 해당 날짜의 레코드를 반환하는 API로 변경하였습니다.

## 변경사항
- requestDto에 date받도록 변경
- date 유무에 따라 레코드 조회 분기
- builder사용한거 없도록 바꿈
