### PR TITLE
[BE-211] 내 댓글 기능에서 반환 값 변경으로 인한 수정

### DIFF
--- a/src/main/java/com/recordit/server/controller/CommentController.java
+++ b/src/main/java/com/recordit/server/controller/CommentController.java
@@ -20,6 +20,7 @@ import com.recordit.server.dto.comment.CommentRequestDto;
 import com.recordit.server.dto.comment.CommentResponseDto;
 import com.recordit.server.dto.comment.ModifyCommentRequestDto;
 import com.recordit.server.dto.comment.MyCommentRequestDto;
+import com.recordit.server.dto.comment.MyCommentResponseDto;
 import com.recordit.server.dto.comment.WriteCommentRequestDto;
 import com.recordit.server.dto.comment.WriteCommentResponseDto;
 import com.recordit.server.exception.ErrorMessage;
@@ -143,7 +144,7 @@ public class CommentController {
 			)
 	})
 	@GetMapping("/my")
-	public ResponseEntity getMyComments(@ModelAttribute @Valid MyCommentRequestDto myCommentRequestDto) {
+	public ResponseEntity<MyCommentResponseDto> getMyComments(@Valid MyCommentRequestDto myCommentRequestDto) {
 		return ResponseEntity.ok().body(commentService.getMyComments(myCommentRequestDto));
 	}
 }

--- a/src/main/java/com/recordit/server/dto/comment/MyCommentDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentDto.java
@@ -16,60 +16,30 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyCommentDto {
-	@ApiModelProperty(notes = "레코드의 카테고리 이름")
-	private String categoryName;
+	@ApiModelProperty(notes = "댓글을 작성한 회원의 닉네임")
+	private String nickname;
 
-	@ApiModelProperty(notes = "레코드 아이디")
-	private Long recordId;
-
-	@ApiModelProperty(notes = "레코드의 제목")
-	private String title;
-
-	@ApiModelProperty(notes = "레코드의 아이콘 이름")
-	private String iconName;
-
-	@ApiModelProperty(notes = "레코드의 색상 이름")
-	private String colorName;
-
-	@ApiModelProperty(notes = "레코드 작성 시각")
-	private LocalDateTime recordCreatedAt;
-
-	@ApiModelProperty(notes = "레코드에 달린 댓글 내용")
-	private String commentContent;
-
-	@ApiModelProperty(notes = "레코드에 달린 댓글 작성 시간")
+	@ApiModelProperty(notes = "댓글이 생성된 시각")
 	private LocalDateTime commentCreatedAt;
 
+	@ApiModelProperty(notes = "댓글의 내용")
+	private String content;
+
 	private MyCommentDto(
-			String categoryName,
-			Long recordId,
-			String title,
-			String iconName,
-			String colorName,
-			LocalDateTime recordCreatedAt,
-			String commentContent,
-			LocalDateTime commentCreatedAt
+			String nickname,
+			LocalDateTime commentCreatedAt,
+			String content
 	) {
-		this.categoryName = categoryName;
-		this.recordId = recordId;
-		this.title = title;
-		this.iconName = iconName;
-		this.colorName = colorName;
-		this.recordCreatedAt = recordCreatedAt;
-		this.commentContent = commentContent;
+		this.nickname = nickname;
 		this.commentCreatedAt = commentCreatedAt;
+		this.content = content;
 	}
 
 	public static MyCommentDto of(Comment comment) {
 		return new MyCommentDto(
-				comment.getRecord().getRecordCategory().getName(),
-				comment.getRecord().getId(),
-				comment.getRecord().getTitle(),
-				comment.getRecord().getRecordIcon().getName(),
-				comment.getRecord().getRecordColor().getName(),
-				comment.getRecord().getCreatedAt(),
-				comment.getContent(),
-				comment.getCreatedAt()
+				comment.getWriter().getNickname(),
+				comment.getCreatedAt(),
+				comment.getContent()
 		);
 	}
 }

--- a/src/main/java/com/recordit/server/dto/comment/MyCommentDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentDto.java
@@ -16,20 +16,25 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyCommentDto {
-	@ApiModelProperty(notes = "댓글을 작성한 회원의 닉네임")
+	@ApiModelProperty(notes = "댓글의 야이디", required = true)
+	private Long commentId;
+
+	@ApiModelProperty(notes = "댓글을 작성한 회원의 닉네임", required = true, example = "열정")
 	private String nickname;
 
-	@ApiModelProperty(notes = "댓글이 생성된 시각")
+	@ApiModelProperty(notes = "댓글이 생성된 시각", required = true)
 	private LocalDateTime commentCreatedAt;
 
-	@ApiModelProperty(notes = "댓글의 내용")
+	@ApiModelProperty(notes = "댓글의 내용", required = true, example = "댓글내용")
 	private String content;
 
 	private MyCommentDto(
+			Long commentId,
 			String nickname,
 			LocalDateTime commentCreatedAt,
 			String content
 	) {
+		this.commentId = commentId;
 		this.nickname = nickname;
 		this.commentCreatedAt = commentCreatedAt;
 		this.content = content;
@@ -37,6 +42,7 @@ public class MyCommentDto {
 
 	public static MyCommentDto of(Comment comment) {
 		return new MyCommentDto(
+				comment.getId(),
 				comment.getWriter().getNickname(),
 				comment.getCreatedAt(),
 				comment.getContent()

--- a/src/main/java/com/recordit/server/dto/comment/MyCommentResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentResponseDto.java
@@ -1,11 +1,13 @@
 package com.recordit.server.dto.comment;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 
 import com.recordit.server.domain.Comment;
+import com.recordit.server.domain.Record;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -19,33 +21,35 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyCommentResponseDto {
-	@ApiModelProperty(notes = "내가 작성한 댓글의 전체 페이지 개수", required = true)
+	@ApiModelProperty(notes = "내가 작성한 댓글이 속한 레코드의 전체 페이지 개수", required = true)
 	private Integer totalPage;
 
-	@ApiModelProperty(notes = "내가 작성한 댓글의 전체 개수", required = true)
+	@ApiModelProperty(notes = "내가 작성한 댓글이 속한 레코드의 전체 개수", required = true)
 	private Long totalCount;
 
-	@ApiModelProperty(notes = "내가 작성한 댓글 리스트", required = true)
-	private List<MyCommentDto> myCommentDtos;
+	@ApiModelProperty(notes = "내가 작성한 댓글이 속한 레코드정보와 내가 작성한 댓글 리스트", required = true)
+	private List<MyCommentsDto> myCommentsDtos;
 
 	private MyCommentResponseDto(
 			Integer totalPage,
 			Long totalCount,
-			List<MyCommentDto> myCommentDtos
+			List<MyCommentsDto> myCommentsDtos
 	) {
 		this.totalPage = totalPage;
 		this.totalCount = totalCount;
-		this.myCommentDtos = myCommentDtos;
+		this.myCommentsDtos = myCommentsDtos;
 	}
 
-	public static MyCommentResponseDto of(Page<Comment> comments) {
+	public static MyCommentResponseDto of(
+			Page<Record> recordPage,
+			LinkedHashMap<Record, List<Comment>> recordListLinkedHashMap
+	) {
 		return new MyCommentResponseDto(
-				comments.getTotalPages(),
-				comments.getTotalElements(),
-				comments.getContent().stream()
-						.map(
-								comment -> MyCommentDto.of(comment)
-						).collect(Collectors.toList())
+				recordPage.getTotalPages(),
+				recordPage.getTotalElements(),
+				recordListLinkedHashMap.keySet().stream().map(
+						record -> MyCommentsDto.of(record, recordListLinkedHashMap.get(record))
+				).collect(Collectors.toList())
 		);
 	}
 }

--- a/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
@@ -1,0 +1,83 @@
+package com.recordit.server.dto.comment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.recordit.server.domain.Comment;
+import com.recordit.server.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@ApiModel
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyCommentsDto {
+	@ApiModelProperty(notes = "레코드의 카테고리 이름")
+	private String categoryName;
+
+	@ApiModelProperty(notes = "레코드 아이디")
+	private Long recordId;
+
+	@ApiModelProperty(notes = "레코드의 제목")
+	private String title;
+
+	@ApiModelProperty(notes = "레코드의 아이콘 이름")
+	private String iconName;
+
+	@ApiModelProperty(notes = "레코드의 색상 이름")
+	private String colorName;
+
+	@ApiModelProperty(notes = "레코드 작성 시각")
+	private LocalDateTime recordCreatedAt;
+
+	@ApiModelProperty(notes = "레코드에 달린 모든 댓글 갯수")
+	private Integer commentsCount;
+
+	@ApiModelProperty(notes = "내가 작성한 댓글 리스트")
+	private List<MyCommentDto> myCommentDtos;
+
+	private MyCommentsDto(
+			String categoryName,
+			Long recordId,
+			String title,
+			String iconName,
+			String colorName,
+			Integer commentsCount,
+			LocalDateTime recordCreatedAt,
+			List<MyCommentDto> myCommentDtos
+	) {
+		this.categoryName = categoryName;
+		this.recordId = recordId;
+		this.title = title;
+		this.iconName = iconName;
+		this.colorName = colorName;
+		this.commentsCount = commentsCount;
+		this.recordCreatedAt = recordCreatedAt;
+		this.myCommentDtos = myCommentDtos;
+	}
+
+	public static MyCommentsDto of(
+			Record record,
+			List<Comment> myComments
+	) {
+		return new MyCommentsDto(
+				record.getRecordCategory().getName(),
+				record.getId(),
+				record.getTitle(),
+				record.getRecordIcon().getName(),
+				record.getRecordColor().getName(),
+				record.getComments().size(),
+				record.getCreatedAt(),
+				myComments.stream().map(
+						comment -> MyCommentDto.of(comment)
+				).collect(Collectors.toList())
+		);
+	}
+}

--- a/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
@@ -19,28 +19,28 @@ import lombok.ToString;
 @ApiModel
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyCommentsDto {
-	@ApiModelProperty(notes = "레코드의 카테고리 이름")
+	@ApiModelProperty(notes = "레코드의 카테고리 이름", required = true, example = "축하해주세요")
 	private String categoryName;
 
-	@ApiModelProperty(notes = "레코드 아이디")
+	@ApiModelProperty(notes = "레코드 아이디", required = true)
 	private Long recordId;
 
-	@ApiModelProperty(notes = "레코드의 제목")
+	@ApiModelProperty(notes = "레코드의 제목", required = true, example = "제목")
 	private String title;
 
-	@ApiModelProperty(notes = "레코드의 아이콘 이름")
+	@ApiModelProperty(notes = "레코드의 아이콘 이름", required = true, example = "moon")
 	private String iconName;
 
-	@ApiModelProperty(notes = "레코드의 색상 이름")
+	@ApiModelProperty(notes = "레코드의 색상 이름", required = true, example = "icon-pink")
 	private String colorName;
 
-	@ApiModelProperty(notes = "레코드 작성 시각")
+	@ApiModelProperty(notes = "레코드 작성 시각", required = true)
 	private LocalDateTime recordCreatedAt;
 
-	@ApiModelProperty(notes = "레코드에 달린 모든 댓글 갯수")
+	@ApiModelProperty(notes = "레코드에 달린 모든 댓글 갯수", required = true)
 	private Integer commentsCount;
 
-	@ApiModelProperty(notes = "내가 작성한 댓글 리스트")
+	@ApiModelProperty(notes = "내가 작성한 댓글 리스트", required = true)
 	private List<MyCommentDto> myCommentDtos;
 
 	private MyCommentsDto(

--- a/src/main/java/com/recordit/server/repository/CommentRepository.java
+++ b/src/main/java/com/recordit/server/repository/CommentRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.recordit.server.domain.Comment;
-import com.recordit.server.domain.Member;
 import com.recordit.server.domain.Record;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -32,7 +31,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@EntityGraph(attributePaths = {"record", "record.recordColor", "record.recordIcon"})
 	List<Comment> findByRecord(Record fixRecord);
-
-	@EntityGraph(attributePaths = {"record", "record.recordCategory", "record.recordColor", "record.recordIcon"})
-	Page<Comment> findByWriter(Member writer, Pageable pageable);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -104,11 +104,10 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			LocalDateTime endTime
 	);
 
+	@Query("select distinct r from RECORD r left join r.comments rs where rs.writer = :writer")
+	Page<Record> findDistinctRecordsByCommentWriter(@Param("writer") Member member, Pageable pageable);
+
 	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor", "comments"})
-	@Query("select r from RECORD r "
-			+ "where r in "
-			+ "(select distinct r from RECORD r "
-			+ "left join r.comments cs where cs.writer = :writer) "
-	)
-	Page<Record> findRecordsByDistinctCommentWriter(@Param("writer") Member member, Pageable pageable);
+	@Query("select r from RECORD r where r in :records")
+	List<Record> findByRecordIn(@Param("records") List<Record> records);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -103,4 +103,12 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 			LocalDateTime startTime,
 			LocalDateTime endTime
 	);
+
+	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor", "comments"})
+	@Query("select r from RECORD r "
+			+ "where r in "
+			+ "(select distinct r from RECORD r "
+			+ "left join r.comments cs where cs.writer = :writer) "
+	)
+	Page<Record> findRecordsByDistinctCommentWriter(@Param("writer") Member member, Pageable pageable);
 }

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -233,10 +233,12 @@ public class CommentService {
 				Sort.by(Sort.Direction.DESC, "createdAt")
 		);
 
-		Page<Record> records = recordRepository.findRecordsByDistinctCommentWriter(member, pageRequest);
+		Page<Record> recordPage = recordRepository.findDistinctRecordsByCommentWriter(member, pageRequest);
+		List<Record> records = recordRepository.findByRecordIn(recordPage.getContent());
+
 		LinkedHashMap<Record, List<Comment>> recordListLinkedHashMap = new LinkedHashMap<>();
 
-		for (Record record : records.getContent()) {
+		for (Record record : records) {
 			recordListLinkedHashMap.put(
 					record,
 					record.getComments()
@@ -248,6 +250,6 @@ public class CommentService {
 			);
 		}
 
-		return MyCommentResponseDto.of(records, recordListLinkedHashMap);
+		return MyCommentResponseDto.of(recordPage, recordListLinkedHashMap);
 	}
 }

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -243,7 +243,8 @@ public class CommentService {
 					record,
 					record.getComments()
 							.stream()
-							.filter(comment -> comment.getWriter().getId().equals(member.getId()))
+							.filter(comment -> comment.getWriter() != null
+									&& comment.getWriter().getId().equals(member.getId()))
 							.sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
 							.limit(3L)
 							.collect(Collectors.toList())

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -533,8 +533,8 @@ public class CommentServiceTest {
 				Sort.by(Sort.Direction.DESC, "createdAt")
 		);
 
-		List<Comment> commentList = List.of(mock(Comment.class));
-		Page<Comment> commentPage = new PageImpl<>(commentList, pageRequest, 1);
+		List<Record> recordList = List.of(mock(Record.class));
+		Page<Record> recordPage = new PageImpl<>(recordList, pageRequest, 1);
 
 		@Test
 		@DisplayName("회원_정보를_찾을 수 없다면 예외를 던진다")
@@ -562,21 +562,18 @@ public class CommentServiceTest {
 			given(memberRepository.findById(memberId))
 					.willReturn(Optional.of(member));
 
-			given(commentRepository.findByWriter(member, pageRequest))
-					.willReturn(commentPage);
+			given(recordRepository.findRecordsByDistinctCommentWriter(member, pageRequest))
+					.willReturn(recordPage);
 
-			given(commentPage.getContent().get(0).getRecord())
-					.willReturn(mock(Record.class));
-
-			given(commentPage.getContent().get(0).getRecord().getRecordCategory())
+			given(recordPage.getContent().get(0).getRecordCategory())
 					.willReturn(mock(RecordCategory.class));
 
-			given(commentPage.getContent().get(0).getRecord().getRecordIcon())
+			given(recordPage.getContent().get(0).getRecordIcon())
 					.willReturn(mock(RecordIcon.class));
 
-			given(commentPage.getContent().get(0).getRecord().getRecordColor())
+			given(recordPage.getContent().get(0).getRecordColor())
 					.willReturn(mock(RecordColor.class));
-			
+
 			//when, then
 			assertThatCode(() -> commentService.getMyComments(myCommentRequestDto))
 					.doesNotThrowAnyException();

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -562,8 +562,11 @@ public class CommentServiceTest {
 			given(memberRepository.findById(memberId))
 					.willReturn(Optional.of(member));
 
-			given(recordRepository.findRecordsByDistinctCommentWriter(member, pageRequest))
+			given(recordRepository.findDistinctRecordsByCommentWriter(member, pageRequest))
 					.willReturn(recordPage);
+
+			given(recordRepository.findByRecordIn(recordList))
+					.willReturn(recordList);
 
 			given(recordPage.getContent().get(0).getRecordCategory())
 					.willReturn(mock(RecordCategory.class));


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [이슈번호 / 이슈내용](https://recodeit.atlassian.net/browse/이슈번호) -->
- [BE-211/ 내 댓글 기능에서 반환 값 변경으로 인한 수정](https://recodeit.atlassian.net/browse/BE-211)
## 설명
기존에 내가 작성한 댓글을 리스트로 보여주는 형식에서 내가 작성한 댓글이 소속된 레코드와 해당 레코드에 존재하는 내가 작성한 댓글, 해당 레코드의 전체 댓글갯수를 반환하는 형식으로 변경하였습니다.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
 - [x] 내 댓글 기능에서 fetch join과 paging을 같이사용할때 발생하는 메모리문제를 해결하기위해 쿼리를 2개로 분리하였습니다.
 - [x]  스웨거 반환값 설정
 - [x]  컨트롤러에서 @ModelAttribute 어노테이션 삭제 
 - [x]  익명 댓글을 확인하는 로직 추가
## 질문사항
