### PR TITLE
[BE-233] 닉네임 변경 시 중복된다면 예외 처리

### DIFF
--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -107,6 +107,7 @@ public class MemberService {
 		Member member = memberRepository.findById(userIdBySession)
 				.orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
 
+		isDuplicateNickname(modifyMemberRequestDto.getNickName());
 		return member.modify(modifyMemberRequestDto);
 	}
 

--- a/src/test/java/com/recordit/server/service/MemberServiceTest.java
+++ b/src/test/java/com/recordit/server/service/MemberServiceTest.java
@@ -291,6 +291,25 @@ public class MemberServiceTest {
 		}
 
 		@Test
+		@DisplayName("변경할_닉네임이_이미_사용중이라면_예외를_던진다")
+		void 변경할_닉네임이_이미_사용중이라면_예외를_던진다() {
+			// given
+			given(sessionUtil.findUserIdBySession())
+					.willReturn(memberId);
+
+			given(memberRepository.findById(memberId))
+					.willReturn(Optional.of(mockMember));
+
+			given(memberRepository.existsByNickname(anyString()))
+					.willReturn(true);
+
+			// when, then
+			assertThatThrownBy(() -> memberService.modifyMember(modifyMemberRequestDto))
+					.isInstanceOf(DuplicateNicknameException.class)
+					.hasMessage("중복된 닉네임이 존재합니다.");
+		}
+
+		@Test
 		@DisplayName("정상적이라면 예외를 던지지 않는다")
 		void 정상적이라면_예외를_던지지_않는다() {
 			//given


### PR DESCRIPTION
## 관련 이슈 번호
- [BE-233 / 닉네임 변경 시 중복된다면 예외 처리](https://recodeit.atlassian.net/browse/BE-233)

## 설명
닉네임 변경 중 중복된 닉네임의 경우 예외를 처리하지 않아
같은 닉네임으로 수정되고 있는 상황이라
예외처리하였습니다

## 변경사항
- [x] MemberService.java modifyMember 메서드에 닉네임 중복 시 예외처리

## 질문사항
