### PR TITLE
[BE-211] 반환값에 레코드 작성자 닉네임 추가 및 레코드 조회시 정렬 로직 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
+++ b/src/main/java/com/recordit/server/dto/comment/MyCommentsDto.java
@@ -25,6 +25,9 @@ public class MyCommentsDto {
 	@ApiModelProperty(notes = "레코드 아이디", required = true)
 	private Long recordId;
 
+	@ApiModelProperty(notes = "레코드 작성자 닉네임", required = true)
+	private String recordWriterNickname;
+
 	@ApiModelProperty(notes = "레코드의 제목", required = true, example = "제목")
 	private String title;
 
@@ -46,6 +49,7 @@ public class MyCommentsDto {
 	private MyCommentsDto(
 			String categoryName,
 			Long recordId,
+			String recordWriterNickname,
 			String title,
 			String iconName,
 			String colorName,
@@ -55,6 +59,7 @@ public class MyCommentsDto {
 	) {
 		this.categoryName = categoryName;
 		this.recordId = recordId;
+		this.recordWriterNickname = recordWriterNickname;
 		this.title = title;
 		this.iconName = iconName;
 		this.colorName = colorName;
@@ -70,6 +75,7 @@ public class MyCommentsDto {
 		return new MyCommentsDto(
 				record.getRecordCategory().getName(),
 				record.getId(),
+				record.getWriter().getNickname(),
 				record.getTitle(),
 				record.getRecordIcon().getName(),
 				record.getRecordColor().getName(),

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -108,6 +108,6 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	Page<Record> findDistinctRecordsByCommentWriter(@Param("writer") Member member, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor", "comments"})
-	@Query("select r from RECORD r where r in :records")
+	@Query("select r from RECORD r where r in :records order by r.createdAt desc")
 	List<Record> findByRecordIn(@Param("records") List<Record> records);
 }

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -233,9 +233,7 @@ public class CommentService {
 		);
 
 		Page<Record> recordPage = recordRepository.findDistinctRecordsByCommentWriter(member, pageRequest);
-		List<Record> records = recordRepository.findByRecordIn(recordPage.getContent()).stream()
-				.sorted(Comparator.comparing(Record::getCreatedAt).reversed())
-				.collect(Collectors.toList());
+		List<Record> records = recordRepository.findByRecordIn(recordPage.getContent());
 
 		LinkedHashMap<Record, List<Comment>> recordListLinkedHashMap = new LinkedHashMap<>();
 

--- a/src/main/java/com/recordit/server/service/CommentService.java
+++ b/src/main/java/com/recordit/server/service/CommentService.java
@@ -229,12 +229,13 @@ public class CommentService {
 
 		PageRequest pageRequest = PageRequest.of(
 				myCommentRequestDto.getPage(),
-				myCommentRequestDto.getSize(),
-				Sort.by(Sort.Direction.DESC, "createdAt")
+				myCommentRequestDto.getSize()
 		);
 
 		Page<Record> recordPage = recordRepository.findDistinctRecordsByCommentWriter(member, pageRequest);
-		List<Record> records = recordRepository.findByRecordIn(recordPage.getContent());
+		List<Record> records = recordRepository.findByRecordIn(recordPage.getContent()).stream()
+				.sorted(Comparator.comparing(Record::getCreatedAt).reversed())
+				.collect(Collectors.toList());
 
 		LinkedHashMap<Record, List<Comment>> recordListLinkedHashMap = new LinkedHashMap<>();
 

--- a/src/test/java/com/recordit/server/service/CommentServiceTest.java
+++ b/src/test/java/com/recordit/server/service/CommentServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -529,8 +528,7 @@ public class CommentServiceTest {
 		Member member = mock(Member.class);
 		PageRequest pageRequest = PageRequest.of(
 				myCommentRequestDto.getPage(),
-				myCommentRequestDto.getSize(),
-				Sort.by(Sort.Direction.DESC, "createdAt")
+				myCommentRequestDto.getSize()
 		);
 
 		List<Record> recordList = List.of(mock(Record.class));
@@ -567,6 +565,9 @@ public class CommentServiceTest {
 
 			given(recordRepository.findByRecordIn(recordList))
 					.willReturn(recordList);
+
+			given(recordPage.getContent().get(0).getWriter())
+					.willReturn(mock(Member.class));
 
 			given(recordPage.getContent().get(0).getRecordCategory())
 					.willReturn(mock(RecordCategory.class));


### PR DESCRIPTION
## 관련 이슈 번호

<!-- - [BE-211/ 반환값에 레코드 작성자 닉네임 추가 및 레코드 조회시 정렬 로직 변경](https://recodeit.atlassian.net/browse/BE-211) -->

## 설명
리턴값에 레코드 작성자의 닉네임 추가, 해당 회원이 작성한 댓글이 달려있는 레코드 조회시 in을 사용할 경우 정렬이 제대로 적용되지 않아 조회후 애플리케이션에서 정렬을 하였음.
## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] 레코드 조회시 정렬을 애플리케이션단이아닌 DB단에서 수행하도록 변경하였습니다.
## 질문사항
