### PR TITLE
[BE-234] 레코드 랭킹 조회시 랭킹 집계 시각도 반환하도록 변경

### DIFF
--- a/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
+++ b/src/main/java/com/recordit/server/dto/record/ranking/RecordRankingResponseDto.java
@@ -1,5 +1,6 @@
 package com.recordit.server.dto.record.ranking;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import io.swagger.annotations.ApiModel;
@@ -15,12 +16,17 @@ import lombok.ToString;
 public class RecordRankingResponseDto {
 
 	private List<RecordRankingDto> recordRankingDtos;
+	private LocalDateTime rankingAggregationTime;
 
-	private RecordRankingResponseDto(List<RecordRankingDto> recordRankingDtos) {
+	private RecordRankingResponseDto(List<RecordRankingDto> recordRankingDtos, LocalDateTime rankingAggregationTime) {
 		this.recordRankingDtos = recordRankingDtos;
+		this.rankingAggregationTime = rankingAggregationTime;
 	}
 
-	public static RecordRankingResponseDto of(List<RecordRankingDto> recordRankingDtos) {
-		return new RecordRankingResponseDto(recordRankingDtos);
+	public static RecordRankingResponseDto of(
+			List<RecordRankingDto> recordRankingDtos,
+			LocalDateTime rankingAggregationTime
+	) {
+		return new RecordRankingResponseDto(recordRankingDtos, rankingAggregationTime);
 	}
 }

--- a/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
+++ b/src/main/java/com/recordit/server/exception/record/RecordExceptionHandler.java
@@ -70,4 +70,11 @@ public class RecordExceptionHandler {
 		return ResponseEntity.badRequest()
 				.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
+
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ErrorMessage> handleIllegalStateException(
+			IllegalStateException exception) {
+		return ResponseEntity.internalServerError()
+				.body(ErrorMessage.of(exception, HttpStatus.INTERNAL_SERVER_ERROR));
+	}
 }

--- a/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
+++ b/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
@@ -16,7 +16,7 @@ public class RecordRankingScheduler {
 	private final RecordRankingService recordRankingService;
 
 	// 매 30분 마다
-	@Scheduled(cron = "0 0/30 * * * ?")
+	@Scheduled(cron = "0 0/1 * * * ?")
 	public void updateRecordRanking() {
 		log.info("레코드 랭킹 집계 스케쥴러 실행");
 		recordRankingService.updateRecordRanking();

--- a/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
+++ b/src/main/java/com/recordit/server/scheduler/RecordRankingScheduler.java
@@ -16,7 +16,7 @@ public class RecordRankingScheduler {
 	private final RecordRankingService recordRankingService;
 
 	// 매 30분 마다
-	@Scheduled(cron = "0 0/1 * * * ?")
+	@Scheduled(cron = "0 0/30 * * * ?")
 	public void updateRecordRanking() {
 		log.info("레코드 랭킹 집계 스케쥴러 실행");
 		recordRankingService.updateRecordRanking();

--- a/src/main/java/com/recordit/server/service/RecordRankingService.java
+++ b/src/main/java/com/recordit/server/service/RecordRankingService.java
@@ -48,7 +48,7 @@ public class RecordRankingService {
 		);
 
 		LocalDateTime rankingAggregationTime = redisManager.get(RANKING_AGGREGATION_TIME, LocalDateTime.class)
-				.orElseThrow(() -> new IllegalStateException());
+				.orElseThrow(() -> new IllegalStateException("랭킹 집계시 집계 시간이 저장되지 않았습니다."));
 
 		return RecordRankingResponseDto.of(recordRanking, rankingAggregationTime);
 	}


### PR DESCRIPTION
## 관련 이슈 번호

[BE-234 / 레코드 랭킹 조회시 랭킹 집계 시각도 반환하도록 변경](https://recodeit.atlassian.net/browse/BE-234)

## 설명
- 레코드 랭킹 집계시 레디스에 집계 시간을 저장하도록 수정
- 랭킹 조회시에 집계 시간을 같이 반환하도록 수정

## 변경사항

<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
