### PR TITLE
[BE-237] 회원 탈퇴 시 세션 초기화, 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/com/recordit/server/repository/CommentRepository.java
+++ b/src/main/java/com/recordit/server/repository/CommentRepository.java
@@ -40,4 +40,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	@Modifying
 	@Query("update COMMENT c set c.deletedAt = CURRENT_TIMESTAMP where c.writer = :writer and c.deletedAt is null")
 	void deleteByWriter(@Param("writer") Member writer);
+
+	List<Comment> findAllByWriter(Member member);
 }

--- a/src/main/java/com/recordit/server/repository/ImageFileRepository.java
+++ b/src/main/java/com/recordit/server/repository/ImageFileRepository.java
@@ -3,6 +3,7 @@ package com.recordit.server.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.recordit.server.constant.RefType;
@@ -14,9 +15,14 @@ public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
 
 	List<ImageFile> findAllByRefTypeAndRefId(RefType refType, Long refId);
 
+	@EntityGraph(attributePaths = "saveName")
+	List<ImageFile> findAllByRefTypeAndRefIdIn(RefType refType, List<Long> refId);
+
 	void deleteAllByRefTypeAndRefIdAndSaveNameIn(
 			RefType refType,
 			Long refId,
 			List<String> attachmentFileNames
 	);
+
+	void deleteAllByRefTypeAndRefIdIn(RefType refType, List<Long> refIds);
 }

--- a/src/main/java/com/recordit/server/repository/RecordRepository.java
+++ b/src/main/java/com/recordit/server/repository/RecordRepository.java
@@ -117,4 +117,6 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	@EntityGraph(attributePaths = {"recordCategory", "recordIcon", "recordColor", "comments"})
 	@Query("select r from RECORD r where r in :records order by r.createdAt desc")
 	List<Record> findByRecordIn(@Param("records") List<Record> records);
+
+	List<Record> findAllByWriter(Member member);
 }

--- a/src/main/java/com/recordit/server/service/ImageFileService.java
+++ b/src/main/java/com/recordit/server/service/ImageFileService.java
@@ -136,6 +136,23 @@ public class ImageFileService {
 		}
 	}
 
+	@Transactional
+	public void deleteToList(
+			@NonNull RefType refType,
+			@NonNull List<Long> refIds
+	) {
+		List<String> attachmentFileNames = imageFileRepository.findAllByRefTypeAndRefIdIn(refType, refIds).stream()
+				.map(ImageFile::getSaveName)
+				.collect(Collectors.toList());
+
+		imageFileRepository.deleteAllByRefTypeAndRefIdIn(refType, refIds);
+
+		for (String attachmentFileName : attachmentFileNames) {
+			s3Uploader.delete(attachmentFileName);
+			log.info("저장한 이미지 파일 삭제 : {}", attachmentFileName);
+		}
+	}
+
 	private void validateImageContentType(MultipartFile multipartFile) {
 		if (!multipartFile.getContentType().startsWith("image")) {
 			log.warn("요청 파일 ContentType : {}", multipartFile.getContentType());

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -157,8 +157,9 @@ public class MemberService {
 		memberRepository.delete(member);
 		memberDeleteHistoryRepository.save(MemberDeleteHistory.of(member.getId()));
 
-		List<Record> records = recordRepository.findAllByWriter(member);
-		imageFileService.deleteToList(RefType.RECORD, records.stream().map(Record::getId).collect(Collectors.toList()));
+		List<Long> recordIdList = recordRepository.findAllByWriter(member).stream()
+				.map(Record::getId).collect(Collectors.toList());
+		imageFileService.deleteToList(RefType.RECORD, recordIdList);
 		recordRepository.deleteByWriter(member);
 
 		List<Comment> comments = commentRepository.findAllByWriter(member);

--- a/src/main/java/com/recordit/server/service/MemberService.java
+++ b/src/main/java/com/recordit/server/service/MemberService.java
@@ -4,16 +4,21 @@ import static com.recordit.server.constant.RegisterSessionConstants.*;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.recordit.server.constant.LoginType;
+import com.recordit.server.constant.RefType;
+import com.recordit.server.domain.Comment;
 import com.recordit.server.domain.Member;
 import com.recordit.server.domain.MemberDeleteHistory;
+import com.recordit.server.domain.Record;
 import com.recordit.server.dto.member.LoginRequestDto;
 import com.recordit.server.dto.member.ModifyMemberRequestDto;
 import com.recordit.server.dto.member.RegisterRequestDto;
@@ -45,6 +50,7 @@ public class MemberService {
 	private final SessionUtil sessionUtil;
 	private final RedisManager redisManager;
 	private final MemberDeleteHistoryRepository memberDeleteHistoryRepository;
+	private final ImageFileService imageFileService;
 
 	@Transactional
 	public Optional<RegisterSessionResponseDto> oauthLogin(LoginType loginType, LoginRequestDto loginRequestDto) {
@@ -150,9 +156,17 @@ public class MemberService {
 
 		memberRepository.delete(member);
 		memberDeleteHistoryRepository.save(MemberDeleteHistory.of(member.getId()));
+
+		List<Record> records = recordRepository.findAllByWriter(member);
+		imageFileService.deleteToList(RefType.RECORD, records.stream().map(Record::getId).collect(Collectors.toList()));
 		recordRepository.deleteByWriter(member);
+
+		List<Comment> comments = commentRepository.findAllByWriter(member);
+		imageFileService.deleteToList(RefType.COMMENT,
+				comments.stream().map(Comment::getId).collect(Collectors.toList()));
 		commentRepository.deleteByWriter(member);
 
+		sessionUtil.invalidateSession();
 		return userIdBySession;
 	}
 }


### PR DESCRIPTION
## 관련 이슈 번호
 - [BE-237 / 회원 탈퇴 시 세션 초기화, 이미지 삭제 로직 추가](https://recodeit.atlassian.net/browse/BE-237)

## 설명
회원 탈퇴 시 세션 초기화, 이미지 삭제 코드가 누락되어 추가하였습니다.

## 변경사항
- [x] 회원 탈퇴 시 S3에 이미지, IMAGE_FILE 테이블에서 삭제 로직 추가
- [x] 탈퇴한 회원의 세션을 REDIS에서 삭제
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->

## 질문사항
